### PR TITLE
Add logging retry and send to dlq message flag toogle

### DIFF
--- a/src/main/java/com/tradeshift/amqp/rabbit/properties/TunedRabbitProperties.java
+++ b/src/main/java/com/tradeshift/amqp/rabbit/properties/TunedRabbitProperties.java
@@ -63,6 +63,8 @@ public class TunedRabbitProperties {
 
     private String rabbitTemplateBeanName;
 
+    private boolean enableRetryMessageLog = true;
+
     public TunedRabbitProperties() {
         // Do nothing because this is a empty constructor
     }
@@ -303,4 +305,11 @@ public class TunedRabbitProperties {
         return enableSnakeCaseForQueuesAndExchangeNames ? string.replace('.', '_') : string.replace('_', '.');
     }
 
+    public void setEnableRetryMessageLog(final boolean enableRetryMessageLog) {
+        this.enableRetryMessageLog = enableRetryMessageLog;
+    }
+
+    public boolean isEnableRetryMessageLog() {
+        return enableRetryMessageLog;
+    }
 }

--- a/src/main/java/com/tradeshift/amqp/rabbit/retry/QueueRetryComponent.java
+++ b/src/main/java/com/tradeshift/amqp/rabbit/retry/QueueRetryComponent.java
@@ -43,13 +43,17 @@ public class QueueRetryComponent {
         message.getMessageProperties()
                 .setExpiration(String.valueOf(calculateTtl(properties.getTtlRetryMessage(), qtdRetry, properties.getTtlMultiply())));
         rabbitTemplateHandler.getRabbitTemplate(properties).send(properties.getExchange(), properties.getQueueRetry(), message);
-        log.info("M=sendToRetry, Message={}", message);
+        if (properties.isEnableRetryMessageLog()) {
+            log.info("M=sendToRetry, Message={}", message);
+        }
     }
 
     public void sendToDlq(final Message message, final TunedRabbitProperties properties) {
         message.getMessageProperties().getHeaders().remove(X_DEATH);
         rabbitTemplateHandler.getRabbitTemplate(properties).send(properties.getExchange(), properties.getQueueDlq(), message);
-        log.info("M=sendToDlq, Message={}", message);
+        if (properties.isEnableRetryMessageLog()) {
+            log.info("M=sendToDlq, Message={}", message);
+        }
     }
 
     public int countDeath(final Message message) {

--- a/src/test/java/com/tradeshift/amqp/rabbit/properties/TunedRabbitPropertiesTest.java
+++ b/src/test/java/com/tradeshift/amqp/rabbit/properties/TunedRabbitPropertiesTest.java
@@ -1,6 +1,7 @@
 package com.tradeshift.amqp.rabbit.properties;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 import org.junit.Test;
 
@@ -56,6 +57,13 @@ public class TunedRabbitPropertiesTest {
         assertEquals(queueName.replace("_", ".") + ".retry", queueProperties.getQueueRetry());
         assertEquals(queueName.replace("_", ".") + ".dlq", queueProperties.getQueueDlq());
         assertEquals(ex.replace("_", "."), queueProperties.getExchange());
+    }
+
+    @Test
+    public void should_retry_log_message_flag_be_enabled_by_default() {
+        String queueName = "queue.test.default";
+        TunedRabbitProperties queueProperties = createQueueProperties(queueName, true, false);
+        assertTrue(queueProperties.isEnableRetryMessageLog());
     }
 
     private TunedRabbitProperties createQueueProperties(String queue, boolean defaultRetryDlq, boolean enableSnakeCaseForQueuesAndExchangeNames) {

--- a/src/test/java/com/tradeshift/amqp/rabbit/retry/QueueRetryComponentTest.java
+++ b/src/test/java/com/tradeshift/amqp/rabbit/retry/QueueRetryComponentTest.java
@@ -188,7 +188,6 @@ public class QueueRetryComponentTest {
         queueProperties.setSslConnection(false);
         queueProperties.setTtlMultiply(ttlMultiply);
         queueProperties.setMaxRetriesAttempts(maxRetry);
-
         return queueProperties;
     }
 


### PR DESCRIPTION
There are some situations where if you are using some third party log indexing service, like splunk, you need to have a more fine grained logging handling, to evict to generate a lot of messages that could overrun the service usage daily quota, which blocks the logs from being sent to the service. So I just added a new flag `enableRetryMessageLog` to enable or disable displaying the retry and send to dlq messages, and this flag will be enabled by default.