### PR TITLE
Making the autocreate available for more than 1 queue in the same connection

### DIFF
--- a/src/main/java/com/tradeshift/amqp/autoconfigure/TunedRabbitAutoConfiguration.java
+++ b/src/main/java/com/tradeshift/amqp/autoconfigure/TunedRabbitAutoConfiguration.java
@@ -45,6 +45,7 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.DependsOn;
 import org.springframework.context.annotation.Import;
@@ -55,6 +56,7 @@ import org.springframework.context.annotation.Primary;
 @ConditionalOnClass({RabbitTemplate.class, Channel.class})
 @AutoConfigureBefore(RabbitAutoConfiguration.class)
 @Import({TunedRabbitAutoConfiguration.RabbitPostProcessorConfiguration.class})
+@ComponentScan(basePackageClasses = RabbitComponentsFactory.class)
 public class TunedRabbitAutoConfiguration {
 
     private static final Logger log = LoggerFactory.getLogger(TunedRabbitAutoConfiguration.class);

--- a/src/main/java/com/tradeshift/amqp/autoconfigure/TunedRabbitAutoConfiguration.java
+++ b/src/main/java/com/tradeshift/amqp/autoconfigure/TunedRabbitAutoConfiguration.java
@@ -33,7 +33,6 @@ import org.springframework.amqp.rabbit.config.RabbitListenerConfigUtils;
 import org.springframework.amqp.rabbit.config.SimpleRabbitListenerContainerFactory;
 import org.springframework.amqp.rabbit.connection.CachingConnectionFactory;
 import org.springframework.amqp.rabbit.connection.ConnectionFactory;
-import org.springframework.amqp.rabbit.connection.SimpleRoutingConnectionFactory;
 import org.springframework.amqp.rabbit.core.RabbitAdmin;
 import org.springframework.amqp.rabbit.core.RabbitTemplate;
 import org.springframework.amqp.support.converter.MessageConverter;

--- a/src/main/java/com/tradeshift/amqp/autoconfigure/TunedRabbitAutoConfiguration.java
+++ b/src/main/java/com/tradeshift/amqp/autoconfigure/TunedRabbitAutoConfiguration.java
@@ -269,6 +269,55 @@ public class TunedRabbitAutoConfiguration {
         }
     }
 
+    private CachingConnectionFactory createConnectionsFactoryBean(final TunedRabbitProperties property, String virtualHost) {
+        try {
+            com.rabbitmq.client.ConnectionFactory factory = new com.rabbitmq.client.ConnectionFactory();
+            if (!property.isSslConnection()) {
+                factory.setUsername(property.getUsername());
+                factory.setPassword(property.getPassword());
+            } else {
+                factory.setSaslConfig(DefaultSaslConfig.EXTERNAL);
+                factory.useSslProtocol(TLSContextUtil.tls12ContextFromPKCS12(property.getTlsKeystoreLocation().getInputStream(),
+                        property.getTlsKeystorePassword().toCharArray()));
+            }
+
+            factory.setHost(property.getHost());
+            factory.setPort(property.getPort());
+            factory.setAutomaticRecoveryEnabled(property.isAutomaticRecovery());
+            Optional.ofNullable(property.getVirtualHost()).ifPresent(factory::setVirtualHost);
+
+            return new CachingConnectionFactory(factory);
+        } catch (Exception e) {
+            log.error(String.format("It is not possible create a Connection Factory to Virtual Host %s", virtualHost), e);
+            return null;
+        }
+    }
+
+    private SimpleRabbitListenerContainerFactory createSimpleRabbitListenerContainerFactoryBean(
+            final TunedRabbitProperties property, CachingConnectionFactory connectionFactory) {
+        SimpleRabbitListenerContainerFactory simpleRabbitListenerContainerFactory = new SimpleRabbitListenerContainerFactory();
+        simpleRabbitListenerContainerFactory.setConnectionFactory(connectionFactory);
+        simpleRabbitListenerContainerFactory.setConcurrentConsumers(property.getConcurrentConsumers());
+        simpleRabbitListenerContainerFactory.setMaxConcurrentConsumers(property.getMaxConcurrentConsumers());
+        if (property.isEnableJsonMessageConverter()) {
+            simpleRabbitListenerContainerFactory.setMessageConverter(producerJackson2MessageConverter());
+        } else {
+            simpleRabbitListenerContainerFactory.setMessageConverter(new SimpleMessageConverter());
+        }
+        return simpleRabbitListenerContainerFactory;
+    }
+
+    private RabbitAdmin createRabbitAdminBean(CachingConnectionFactory connectionFactory) {
+        return new RabbitAdmin(connectionFactory);
+    }
+
+    private RabbitTemplate createRabbitTemplateBean(CachingConnectionFactory connectionFactory, final TunedRabbitProperties property) {
+        RabbitTemplate rabbitTemplate = new RabbitTemplate(connectionFactory);
+        if (property.isEnableJsonMessageConverter()) {
+            rabbitTemplate.setMessageConverter(producerJackson2MessageConverter());
+        }
+    }
+
     private void autoCreateQueues(TunedRabbitProperties properties, RabbitAdmin rabbitAdmin) {
         log.info("Declaring binding for exchange '{}', queue '{}' and routing key '{}'", properties.getExchange(), properties.getQueue(), properties.getQueueRoutingKey());
         

--- a/src/main/java/com/tradeshift/amqp/rabbit/components/RabbitComponentsFactory.java
+++ b/src/main/java/com/tradeshift/amqp/rabbit/components/RabbitComponentsFactory.java
@@ -15,76 +15,74 @@ import org.springframework.amqp.rabbit.core.RabbitTemplate;
 import org.springframework.amqp.support.converter.Jackson2JsonMessageConverter;
 import org.springframework.amqp.support.converter.MessageConverter;
 import org.springframework.amqp.support.converter.SimpleMessageConverter;
-import org.springframework.stereotype.Component;
 
 import com.rabbitmq.client.DefaultSaslConfig;
 import com.tradeshift.amqp.rabbit.properties.TunedRabbitProperties;
 import com.tradeshift.amqp.ssl.TLSContextUtil;
 
-@Component
 public class RabbitComponentsFactory {
 	private static final Logger log = LoggerFactory.getLogger(RabbitComponentsFactory.class);
 
-	
-    public RabbitAdmin createRabbitAdminBean(CachingConnectionFactory connectionFactory) {
-        return new RabbitAdmin(connectionFactory);
-    }
+
+	public RabbitAdmin createRabbitAdminBean(CachingConnectionFactory connectionFactory) {
+		return new RabbitAdmin(connectionFactory);
+	}
 
 	public MessageConverter createJackson2MessageConverter() {
 		return new Jackson2JsonMessageConverter();
 	}
 
-    public RabbitTemplate createRabbitTemplateBean(CachingConnectionFactory connectionFactory, final TunedRabbitProperties property) {
-        RabbitTemplate rabbitTemplate = new RabbitTemplate(connectionFactory);
-        if (property.isEnableJsonMessageConverter()) {
-            rabbitTemplate.setMessageConverter(createJackson2MessageConverter());
-        }
-        return rabbitTemplate;
-    }
-
-	public ConnectionFactory createSimpleRoutingConnectionFactory(AtomicReference<ConnectionFactory> defaultConnectionFactory,
-	        HashMap<Object, ConnectionFactory> connectionFactoryHashMap) {
-		SimpleRoutingConnectionFactory connectionFactory = new SimpleRoutingConnectionFactory();
-        connectionFactory.setTargetConnectionFactories(connectionFactoryHashMap);
-        connectionFactory.setDefaultTargetConnectionFactory(defaultConnectionFactory.get());
-        return connectionFactory;
+	public RabbitTemplate createRabbitTemplateBean(CachingConnectionFactory connectionFactory, final TunedRabbitProperties property) {
+		RabbitTemplate rabbitTemplate = new RabbitTemplate(connectionFactory);
+		if (property.isEnableJsonMessageConverter()) {
+			rabbitTemplate.setMessageConverter(createJackson2MessageConverter());
+		}
+		return rabbitTemplate;
 	}
 
-    public CachingConnectionFactory createCachingConnectionFactory(final TunedRabbitProperties property, String virtualHost) {
-        try {
-            com.rabbitmq.client.ConnectionFactory factory = new com.rabbitmq.client.ConnectionFactory();
-            if (!property.isSslConnection()) {
-                factory.setUsername(property.getUsername());
-                factory.setPassword(property.getPassword());
-            } else {
-                factory.setSaslConfig(DefaultSaslConfig.EXTERNAL);
-                factory.useSslProtocol(TLSContextUtil.tls12ContextFromPKCS12(property.getTlsKeystoreLocation().getInputStream(),
-                        property.getTlsKeystorePassword().toCharArray()));
-            }
+	public ConnectionFactory createSimpleRoutingConnectionFactory(AtomicReference<ConnectionFactory> defaultConnectionFactory,
+			HashMap<Object, ConnectionFactory> connectionFactoryHashMap) {
+		SimpleRoutingConnectionFactory connectionFactory = new SimpleRoutingConnectionFactory();
+		connectionFactory.setTargetConnectionFactories(connectionFactoryHashMap);
+		connectionFactory.setDefaultTargetConnectionFactory(defaultConnectionFactory.get());
+		return connectionFactory;
+	}
 
-            factory.setHost(property.getHost());
-            factory.setPort(property.getPort());
-            factory.setAutomaticRecoveryEnabled(property.isAutomaticRecovery());
-            Optional.ofNullable(property.getVirtualHost()).ifPresent(factory::setVirtualHost);
+	public CachingConnectionFactory createCachingConnectionFactory(final TunedRabbitProperties property, String virtualHost) {
+		try {
+			com.rabbitmq.client.ConnectionFactory factory = new com.rabbitmq.client.ConnectionFactory();
+			if (!property.isSslConnection()) {
+				factory.setUsername(property.getUsername());
+				factory.setPassword(property.getPassword());
+			} else {
+				factory.setSaslConfig(DefaultSaslConfig.EXTERNAL);
+				factory.useSslProtocol(TLSContextUtil.tls12ContextFromPKCS12(property.getTlsKeystoreLocation().getInputStream(),
+						property.getTlsKeystorePassword().toCharArray()));
+			}
 
-            return new CachingConnectionFactory(factory);
-        } catch (Exception e) {
-            log.error(String.format("It is not possible create a Connection Factory to Virtual Host %s", virtualHost), e);
-            return null;
-        }
-    }
+			factory.setHost(property.getHost());
+			factory.setPort(property.getPort());
+			factory.setAutomaticRecoveryEnabled(property.isAutomaticRecovery());
+			Optional.ofNullable(property.getVirtualHost()).ifPresent(factory::setVirtualHost);
 
-    public SimpleRabbitListenerContainerFactory createSimpleRabbitListenerContainerFactoryBean(
-            final TunedRabbitProperties property, CachingConnectionFactory connectionFactory) {
-        SimpleRabbitListenerContainerFactory simpleRabbitListenerContainerFactory = new SimpleRabbitListenerContainerFactory();
-        simpleRabbitListenerContainerFactory.setConnectionFactory(connectionFactory);
-        simpleRabbitListenerContainerFactory.setConcurrentConsumers(property.getConcurrentConsumers());
-        simpleRabbitListenerContainerFactory.setMaxConcurrentConsumers(property.getMaxConcurrentConsumers());
-        if (property.isEnableJsonMessageConverter()) {
-            simpleRabbitListenerContainerFactory.setMessageConverter(createJackson2MessageConverter());
-        } else {
-            simpleRabbitListenerContainerFactory.setMessageConverter(new SimpleMessageConverter());
-        }
-        return simpleRabbitListenerContainerFactory;
-    }
+			return new CachingConnectionFactory(factory);
+		} catch (Exception e) {
+			log.error(String.format("It is not possible create a Connection Factory to Virtual Host %s", virtualHost), e);
+			return null;
+		}
+	}
+
+	public SimpleRabbitListenerContainerFactory createSimpleRabbitListenerContainerFactoryBean(
+			final TunedRabbitProperties property, CachingConnectionFactory connectionFactory) {
+		SimpleRabbitListenerContainerFactory simpleRabbitListenerContainerFactory = new SimpleRabbitListenerContainerFactory();
+		simpleRabbitListenerContainerFactory.setConnectionFactory(connectionFactory);
+		simpleRabbitListenerContainerFactory.setConcurrentConsumers(property.getConcurrentConsumers());
+		simpleRabbitListenerContainerFactory.setMaxConcurrentConsumers(property.getMaxConcurrentConsumers());
+		if (property.isEnableJsonMessageConverter()) {
+			simpleRabbitListenerContainerFactory.setMessageConverter(createJackson2MessageConverter());
+		} else {
+			simpleRabbitListenerContainerFactory.setMessageConverter(new SimpleMessageConverter());
+		}
+		return simpleRabbitListenerContainerFactory;
+	}
 }

--- a/src/main/java/com/tradeshift/amqp/rabbit/components/RabbitComponentsFactory.java
+++ b/src/main/java/com/tradeshift/amqp/rabbit/components/RabbitComponentsFactory.java
@@ -1,0 +1,90 @@
+package com.tradeshift.amqp.rabbit.components;
+
+import java.util.HashMap;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.amqp.rabbit.config.SimpleRabbitListenerContainerFactory;
+import org.springframework.amqp.rabbit.connection.CachingConnectionFactory;
+import org.springframework.amqp.rabbit.connection.ConnectionFactory;
+import org.springframework.amqp.rabbit.connection.SimpleRoutingConnectionFactory;
+import org.springframework.amqp.rabbit.core.RabbitAdmin;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import org.springframework.amqp.support.converter.Jackson2JsonMessageConverter;
+import org.springframework.amqp.support.converter.MessageConverter;
+import org.springframework.amqp.support.converter.SimpleMessageConverter;
+import org.springframework.stereotype.Component;
+
+import com.rabbitmq.client.DefaultSaslConfig;
+import com.tradeshift.amqp.rabbit.properties.TunedRabbitProperties;
+import com.tradeshift.amqp.ssl.TLSContextUtil;
+
+@Component
+public class RabbitComponentsFactory {
+	private static final Logger log = LoggerFactory.getLogger(RabbitComponentsFactory.class);
+
+	
+    public RabbitAdmin createRabbitAdminBean(CachingConnectionFactory connectionFactory) {
+        return new RabbitAdmin(connectionFactory);
+    }
+
+	public MessageConverter createJackson2MessageConverter() {
+		return new Jackson2JsonMessageConverter();
+	}
+
+    public RabbitTemplate createRabbitTemplateBean(CachingConnectionFactory connectionFactory, final TunedRabbitProperties property) {
+        RabbitTemplate rabbitTemplate = new RabbitTemplate(connectionFactory);
+        if (property.isEnableJsonMessageConverter()) {
+            rabbitTemplate.setMessageConverter(createJackson2MessageConverter());
+        }
+        return rabbitTemplate;
+    }
+
+	public ConnectionFactory createSimpleRoutingConnectionFactory(AtomicReference<ConnectionFactory> defaultConnectionFactory,
+	        HashMap<Object, ConnectionFactory> connectionFactoryHashMap) {
+		SimpleRoutingConnectionFactory connectionFactory = new SimpleRoutingConnectionFactory();
+        connectionFactory.setTargetConnectionFactories(connectionFactoryHashMap);
+        connectionFactory.setDefaultTargetConnectionFactory(defaultConnectionFactory.get());
+        return connectionFactory;
+	}
+
+    public CachingConnectionFactory createCachingConnectionFactory(final TunedRabbitProperties property, String virtualHost) {
+        try {
+            com.rabbitmq.client.ConnectionFactory factory = new com.rabbitmq.client.ConnectionFactory();
+            if (!property.isSslConnection()) {
+                factory.setUsername(property.getUsername());
+                factory.setPassword(property.getPassword());
+            } else {
+                factory.setSaslConfig(DefaultSaslConfig.EXTERNAL);
+                factory.useSslProtocol(TLSContextUtil.tls12ContextFromPKCS12(property.getTlsKeystoreLocation().getInputStream(),
+                        property.getTlsKeystorePassword().toCharArray()));
+            }
+
+            factory.setHost(property.getHost());
+            factory.setPort(property.getPort());
+            factory.setAutomaticRecoveryEnabled(property.isAutomaticRecovery());
+            Optional.ofNullable(property.getVirtualHost()).ifPresent(factory::setVirtualHost);
+
+            return new CachingConnectionFactory(factory);
+        } catch (Exception e) {
+            log.error(String.format("It is not possible create a Connection Factory to Virtual Host %s", virtualHost), e);
+            return null;
+        }
+    }
+
+    public SimpleRabbitListenerContainerFactory createSimpleRabbitListenerContainerFactoryBean(
+            final TunedRabbitProperties property, CachingConnectionFactory connectionFactory) {
+        SimpleRabbitListenerContainerFactory simpleRabbitListenerContainerFactory = new SimpleRabbitListenerContainerFactory();
+        simpleRabbitListenerContainerFactory.setConnectionFactory(connectionFactory);
+        simpleRabbitListenerContainerFactory.setConcurrentConsumers(property.getConcurrentConsumers());
+        simpleRabbitListenerContainerFactory.setMaxConcurrentConsumers(property.getMaxConcurrentConsumers());
+        if (property.isEnableJsonMessageConverter()) {
+            simpleRabbitListenerContainerFactory.setMessageConverter(createJackson2MessageConverter());
+        } else {
+            simpleRabbitListenerContainerFactory.setMessageConverter(new SimpleMessageConverter());
+        }
+        return simpleRabbitListenerContainerFactory;
+    }
+}

--- a/src/test/java/com/tradeshift/amqp/autoconfigure/TunedRabbitAutoConfigurationBingindTest.java
+++ b/src/test/java/com/tradeshift/amqp/autoconfigure/TunedRabbitAutoConfigurationBingindTest.java
@@ -1,0 +1,163 @@
+package com.tradeshift.amqp.autoconfigure;
+
+import static java.util.stream.Collectors.toList;
+import static org.hamcrest.CoreMatchers.hasItems;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.mockito.MockitoAnnotations.initMocks;
+
+import java.util.List;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.springframework.amqp.core.Exchange;
+import org.springframework.amqp.core.Queue;
+import org.springframework.amqp.rabbit.core.RabbitAdmin;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
+import org.springframework.boot.test.mock.mockito.SpyBean;
+import org.springframework.context.support.GenericApplicationContext;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import com.tradeshift.amqp.rabbit.components.RabbitComponentsFactory;
+import com.tradeshift.amqp.rabbit.properties.TunedRabbitProperties;
+import com.tradeshift.amqp.rabbit.properties.TunedRabbitPropertiesMap;
+
+@RunWith(SpringRunner.class)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
+public class TunedRabbitAutoConfigurationBingindTest {
+
+	private TunedRabbitAutoConfiguration tradeshiftRabbitAutoConfiguration;
+	
+    @Autowired
+    private GenericApplicationContext context;
+
+    @Autowired
+    private ConfigurableListableBeanFactory beanFactory;
+    
+    @SpyBean
+    private RabbitComponentsFactory rabbitComponentsFactory;
+
+	private RabbitAdmin rabbitAdmin;
+    
+    @Before
+    public void setup() {
+        initMocks(this);
+        tradeshiftRabbitAutoConfiguration = spy(new TunedRabbitAutoConfiguration(context, beanFactory));
+        
+        when(tradeshiftRabbitAutoConfiguration.rabbitComponentsFactory()).thenReturn(rabbitComponentsFactory);
+        
+        rabbitAdmin = mock(RabbitAdmin.class);
+    	doReturn(rabbitAdmin).when(rabbitComponentsFactory).createRabbitAdminBean(any());
+    }
+    
+    @Test
+    public void should_create_binding_for_one_event() {
+    	
+    	TunedRabbitPropertiesMap rabbitCustomPropertiesMap = new TunedRabbitPropertiesMap();
+    	TunedRabbitProperties eventProperties = createQueuePropertiesWithAutoCreate(true);
+    	rabbitCustomPropertiesMap.put("some-event", eventProperties);
+
+    	tradeshiftRabbitAutoConfiguration.routingConnectionFactory(rabbitCustomPropertiesMap);
+
+    	// Validate the single exchange
+    	ArgumentCaptor<Exchange> exchangeArgumentCaptor = ArgumentCaptor.forClass(Exchange.class);
+    	verify(rabbitAdmin).declareExchange(exchangeArgumentCaptor.capture());
+    	assertThat(exchangeArgumentCaptor.getValue().getName(), is("ex.test"));
+
+    	// Validate all the queues
+    	ArgumentCaptor<Queue> queueArgumentCaptor = ArgumentCaptor.forClass(Queue.class);
+    	verify(rabbitAdmin, times(3)).declareQueue(queueArgumentCaptor.capture());
+    	List<String> queuesNames = queueArgumentCaptor.getAllValues().stream()
+    			.map(Queue::getName)
+    			.collect(toList());
+    	assertThat(queuesNames, hasItems("queue.test", "queue.test.dlq", "queue.test.retry"));
+    }
+    
+    @Test
+    public void should_not_create_binding_for_retry_and_dlq_when_disabled() {
+    	
+    	TunedRabbitPropertiesMap rabbitCustomPropertiesMap = new TunedRabbitPropertiesMap();
+    	TunedRabbitProperties eventProperties = createQueuePropertiesWithAutoCreate(true);
+    	eventProperties.setAutoCreateForRetryDlq(false);
+    	rabbitCustomPropertiesMap.put("some-event", eventProperties);
+
+    	tradeshiftRabbitAutoConfiguration.routingConnectionFactory(rabbitCustomPropertiesMap);
+
+    	// Validate the single exchange
+    	ArgumentCaptor<Exchange> exchangeArgumentCaptor = ArgumentCaptor.forClass(Exchange.class);
+    	verify(rabbitAdmin).declareExchange(exchangeArgumentCaptor.capture());
+    	assertThat(exchangeArgumentCaptor.getValue().getName(), is("ex.test"));
+
+    	// Validate all the queues
+    	ArgumentCaptor<Queue> queueArgumentCaptor = ArgumentCaptor.forClass(Queue.class);
+    	verify(rabbitAdmin).declareQueue(queueArgumentCaptor.capture());
+    	assertThat(queueArgumentCaptor.getValue().getName(), is("queue.test"));
+    }
+
+    @Test
+    public void should_create_binding_for_events_with_same_host_port_and_virtualhost() {
+
+    	TunedRabbitPropertiesMap rabbitCustomPropertiesMap = new TunedRabbitPropertiesMap();
+    	TunedRabbitProperties eventProperties = createQueuePropertiesWithAutoCreate(true);
+    	rabbitCustomPropertiesMap.put("some-event", eventProperties);
+
+    	eventProperties = createQueuePropertiesWithAutoCreate(false);
+    	eventProperties.setQueue("queue2.test");
+    	eventProperties.setExchange("exchange2.test");
+    	rabbitCustomPropertiesMap.put("some-event2", eventProperties);
+
+    	tradeshiftRabbitAutoConfiguration.routingConnectionFactory(rabbitCustomPropertiesMap);
+
+    	// Validate the two exchanges
+    	ArgumentCaptor<Exchange> exchangeArgumentCaptor = ArgumentCaptor.forClass(Exchange.class);
+    	verify(rabbitAdmin, times(2)).declareExchange(exchangeArgumentCaptor.capture());
+    	List<String> exchangesNames = exchangeArgumentCaptor.getAllValues().stream()
+    			.map(Exchange::getName)
+    			.collect(toList());
+    	assertThat(exchangesNames, hasItems("ex.test", "exchange2.test"));
+
+    	ArgumentCaptor<Queue> queueArgumentCaptor = ArgumentCaptor.forClass(Queue.class);
+    	verify(rabbitAdmin, times(6)).declareQueue(queueArgumentCaptor.capture());
+    	List<String> queuesNames = queueArgumentCaptor.getAllValues().stream()
+    			.map(Queue::getName)
+    			.collect(toList());
+    	assertThat(queuesNames, hasItems("queue.test", "queue.test.dlq", "queue.test.retry",
+    			"queue2.test", "queue2.test.dlq", "queue2.test.retry"));
+    }
+    
+    private TunedRabbitProperties createQueuePropertiesWithAutoCreate(boolean primary) {
+    	return createQueuePropertiesWithAutoCreate(primary, "localhost", 5672, null);
+    }
+
+    private TunedRabbitProperties createQueuePropertiesWithAutoCreate(boolean primary, String host, int port, String virtualHost) {
+    	TunedRabbitProperties queueProperties = new TunedRabbitProperties();
+    	queueProperties.setQueue("queue.test");
+    	queueProperties.setExchange("ex.test");
+    	queueProperties.setExchangeType("topic");
+    	queueProperties.setMaxRetriesAttempts(5);
+    	queueProperties.setQueueRoutingKey("routing.key.test");
+    	queueProperties.setTtlRetryMessage(3000);
+    	queueProperties.setPrimary(primary);
+    	queueProperties.setUsername("guest");
+    	queueProperties.setPassword("guest");
+    	queueProperties.setHost(host);
+    	queueProperties.setPort(port);
+    	queueProperties.setVirtualHost(virtualHost);
+    	queueProperties.setSslConnection(false);
+    	queueProperties.setEnableJsonMessageConverter(false);
+    	queueProperties.setAutoCreate(true);
+
+    	return queueProperties;
+    }
+}

--- a/src/test/java/com/tradeshift/amqp/autoconfigure/TunedRabbitAutoConfigurationTest.java
+++ b/src/test/java/com/tradeshift/amqp/autoconfigure/TunedRabbitAutoConfigurationTest.java
@@ -1,30 +1,16 @@
 package com.tradeshift.amqp.autoconfigure;
 
-import static java.util.stream.Collectors.toList;
-import static org.hamcrest.CoreMatchers.hasItems;
-import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertThat;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
 import static org.mockito.MockitoAnnotations.initMocks;
 
 import java.lang.reflect.Field;
-import java.util.List;
 
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
-import org.mockito.ArgumentCaptor;
-import org.mockito.Spy;
-import org.springframework.amqp.core.Exchange;
-import org.springframework.amqp.core.Queue;
 import org.springframework.amqp.rabbit.config.SimpleRabbitListenerContainerFactory;
 import org.springframework.amqp.rabbit.connection.CachingConnectionFactory;
 import org.springframework.amqp.rabbit.core.RabbitAdmin;
@@ -38,7 +24,6 @@ import org.springframework.context.support.GenericApplicationContext;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.junit4.SpringRunner;
 
-import com.tradeshift.amqp.rabbit.components.RabbitComponentsFactory;
 import com.tradeshift.amqp.rabbit.properties.TunedRabbitProperties;
 import com.tradeshift.amqp.rabbit.properties.TunedRabbitPropertiesMap;
 import com.tradeshift.amqp.resolvers.RabbitBeanNameResolver;
@@ -55,16 +40,13 @@ public class TunedRabbitAutoConfigurationTest {
     @Autowired
     private ConfigurableListableBeanFactory beanFactory;
     
-    @Spy
-    private RabbitComponentsFactory rabbitComponentsFactory;
-    
     @Rule
     public ExpectedException expectedException = ExpectedException.none();
 
     @Before
     public void setup() {
         initMocks(this);
-        tradeshiftRabbitAutoConfiguration = new TunedRabbitAutoConfiguration(context, beanFactory, rabbitComponentsFactory);
+        tradeshiftRabbitAutoConfiguration = new TunedRabbitAutoConfiguration(context, beanFactory);
     }
 
     @Test
@@ -507,97 +489,6 @@ public class TunedRabbitAutoConfigurationTest {
         assertEquals(1, context.getBeansOfType(SimpleRabbitListenerContainerFactory.class).size());
     }
     
-    @Test
-    public void should_create_binding_for_one_event() {
-    	
-    	TunedRabbitPropertiesMap rabbitCustomPropertiesMap = new TunedRabbitPropertiesMap();
-    	TunedRabbitProperties eventProperties = createQueueProperties(true);
-    	eventProperties.setAutoCreate(true);
-    	rabbitCustomPropertiesMap.put("some-event", eventProperties);
-
-    	RabbitAdmin rabbitAdmin = mock(RabbitAdmin.class);
-
-    	doReturn(rabbitAdmin).when(rabbitComponentsFactory).createRabbitAdminBean(any());
-
-    	tradeshiftRabbitAutoConfiguration.routingConnectionFactory(rabbitCustomPropertiesMap);
-
-    	// Validate the single exchange
-    	ArgumentCaptor<Exchange> exchangeArgumentCaptor = ArgumentCaptor.forClass(Exchange.class);
-    	verify(rabbitAdmin).declareExchange(exchangeArgumentCaptor.capture());
-    	assertThat(exchangeArgumentCaptor.getValue().getName(), is("ex.test"));
-
-    	// Validate all the queues
-    	ArgumentCaptor<Queue> queueArgumentCaptor = ArgumentCaptor.forClass(Queue.class);
-    	verify(rabbitAdmin, times(3)).declareQueue(queueArgumentCaptor.capture());
-    	List<String> queuesNames = queueArgumentCaptor.getAllValues().stream()
-    			.map(Queue::getName)
-    			.collect(toList());
-    	assertThat(queuesNames, hasItems("queue.test", "queue.test.dlq", "queue.test.retry"));
-    }
-    
-    @Test
-    public void should_not_create_binding_for_retry_and_dlq_when_disabled() {
-    	
-    	TunedRabbitPropertiesMap rabbitCustomPropertiesMap = new TunedRabbitPropertiesMap();
-    	TunedRabbitProperties eventProperties = createQueueProperties(true);
-    	eventProperties.setAutoCreate(true);
-    	eventProperties.setAutoCreateForRetryDlq(false);
-    	rabbitCustomPropertiesMap.put("some-event", eventProperties);
-
-    	RabbitAdmin rabbitAdmin = mock(RabbitAdmin.class);
-
-    	doReturn(rabbitAdmin).when(rabbitComponentsFactory).createRabbitAdminBean(any());
-
-    	tradeshiftRabbitAutoConfiguration.routingConnectionFactory(rabbitCustomPropertiesMap);
-
-    	// Validate the single exchange
-    	ArgumentCaptor<Exchange> exchangeArgumentCaptor = ArgumentCaptor.forClass(Exchange.class);
-    	verify(rabbitAdmin).declareExchange(exchangeArgumentCaptor.capture());
-    	assertThat(exchangeArgumentCaptor.getValue().getName(), is("ex.test"));
-
-    	// Validate all the queues
-    	ArgumentCaptor<Queue> queueArgumentCaptor = ArgumentCaptor.forClass(Queue.class);
-    	verify(rabbitAdmin).declareQueue(queueArgumentCaptor.capture());
-    	assertThat(queueArgumentCaptor.getValue().getName(), is("queue.test"));
-    }
-
-    @Test
-    public void should_create_binding_for_all_events() {
-
-    	TunedRabbitPropertiesMap rabbitCustomPropertiesMap = new TunedRabbitPropertiesMap();
-    	TunedRabbitProperties eventProperties = createQueueProperties(true);
-    	eventProperties.setAutoCreate(true);
-    	rabbitCustomPropertiesMap.put("some-event", eventProperties);
-
-    	eventProperties = createQueueProperties(false);
-    	eventProperties.setAutoCreate(true);
-    	eventProperties.setQueue("queue2.test");
-    	eventProperties.setExchange("exchange2.test");
-    	rabbitCustomPropertiesMap.put("some-event2", eventProperties);
-
-    	RabbitAdmin rabbitAdmin = mock(RabbitAdmin.class);
-
-    	doReturn(rabbitAdmin).when(rabbitComponentsFactory).createRabbitAdminBean(any());
-
-    	tradeshiftRabbitAutoConfiguration.routingConnectionFactory(rabbitCustomPropertiesMap);
-
-    	// Validate the two exchanges
-    	ArgumentCaptor<Exchange> exchangeArgumentCaptor = ArgumentCaptor.forClass(Exchange.class);
-    	verify(rabbitAdmin, times(2)).declareExchange(exchangeArgumentCaptor.capture());
-    	List<String> exchangesNames = exchangeArgumentCaptor.getAllValues().stream()
-    			.map(Exchange::getName)
-    			.collect(toList());
-    	assertThat(exchangesNames, hasItems("ex.test", "exchange2.test"));
-
-    	ArgumentCaptor<Queue> queueArgumentCaptor = ArgumentCaptor.forClass(Queue.class);
-    	verify(rabbitAdmin, times(6)).declareQueue(queueArgumentCaptor.capture());
-    	List<String> queuesNames = queueArgumentCaptor.getAllValues().stream()
-    			.map(Queue::getName)
-    			.collect(toList());
-    	assertThat(queuesNames, hasItems("queue.test", "queue.test.dlq", "queue.test.retry",
-    			"queue2.test", "queue2.test.dlq", "queue2.test.retry"));
-    }
-
     private TunedRabbitProperties createQueueProperties(boolean primary) {
         return createQueueProperties(primary, null);
     }

--- a/src/test/java/com/tradeshift/amqp/autoconfigure/TunedRabbitAutoConfigurationTest.java
+++ b/src/test/java/com/tradeshift/amqp/autoconfigure/TunedRabbitAutoConfigurationTest.java
@@ -55,13 +55,16 @@ public class TunedRabbitAutoConfigurationTest {
     @Autowired
     private ConfigurableListableBeanFactory beanFactory;
     
+    @Spy
+    private RabbitComponentsFactory rabbitComponentsFactory;
+    
     @Rule
     public ExpectedException expectedException = ExpectedException.none();
 
     @Before
     public void setup() {
         initMocks(this);
-        tradeshiftRabbitAutoConfiguration = new TunedRabbitAutoConfiguration(context, beanFactory, new RabbitComponentsFactory());
+        tradeshiftRabbitAutoConfiguration = new TunedRabbitAutoConfiguration(context, beanFactory, rabbitComponentsFactory);
     }
 
     @Test

--- a/src/test/java/com/tradeshift/amqp/autoconfigure/TunedRabbitAutoConfigurationTest.java
+++ b/src/test/java/com/tradeshift/amqp/autoconfigure/TunedRabbitAutoConfigurationTest.java
@@ -55,16 +55,13 @@ public class TunedRabbitAutoConfigurationTest {
     @Autowired
     private ConfigurableListableBeanFactory beanFactory;
     
-    @Spy
-    private RabbitComponentsFactory rabbitComponentsFactory;
-    
     @Rule
     public ExpectedException expectedException = ExpectedException.none();
 
     @Before
     public void setup() {
         initMocks(this);
-        tradeshiftRabbitAutoConfiguration = new TunedRabbitAutoConfiguration(context, beanFactory, rabbitComponentsFactory);
+        tradeshiftRabbitAutoConfiguration = new TunedRabbitAutoConfiguration(context, beanFactory, new RabbitComponentsFactory());
     }
 
     @Test

--- a/src/test/java/com/tradeshift/amqp/autoconfigure/TunedRabbitAutoConfigurationTest.java
+++ b/src/test/java/com/tradeshift/amqp/autoconfigure/TunedRabbitAutoConfigurationTest.java
@@ -24,6 +24,7 @@ import org.springframework.context.support.GenericApplicationContext;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.junit4.SpringRunner;
 
+import com.tradeshift.amqp.rabbit.components.RabbitComponentsFactory;
 import com.tradeshift.amqp.rabbit.properties.TunedRabbitProperties;
 import com.tradeshift.amqp.rabbit.properties.TunedRabbitPropertiesMap;
 import com.tradeshift.amqp.resolvers.RabbitBeanNameResolver;
@@ -39,14 +40,14 @@ public class TunedRabbitAutoConfigurationTest {
 
     @Autowired
     private ConfigurableListableBeanFactory beanFactory;
-
+    
     @Rule
     public ExpectedException expectedException = ExpectedException.none();
 
     @Before
     public void setup() {
         initMocks(this);
-        tradeshiftRabbitAutoConfiguration = new TunedRabbitAutoConfiguration(context, beanFactory);
+        tradeshiftRabbitAutoConfiguration = new TunedRabbitAutoConfiguration(context, beanFactory, new RabbitComponentsFactory());
     }
 
     @Test

--- a/src/test/java/com/tradeshift/amqp/rabbit/handlers/RabbitAdminHandlerTest.java
+++ b/src/test/java/com/tradeshift/amqp/rabbit/handlers/RabbitAdminHandlerTest.java
@@ -16,6 +16,7 @@ import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.junit4.SpringRunner;
 
 import com.tradeshift.amqp.autoconfigure.TunedRabbitAutoConfiguration;
+import com.tradeshift.amqp.rabbit.components.RabbitComponentsFactory;
 import com.tradeshift.amqp.rabbit.properties.TunedRabbitProperties;
 import com.tradeshift.amqp.rabbit.properties.TunedRabbitPropertiesMap;
 
@@ -30,7 +31,7 @@ public class RabbitAdminHandlerTest {
 
     @Autowired
     private ConfigurableListableBeanFactory beanFactory;
-
+    
     private RabbitAdminHandler rabbitAdminHandler;
 
     @Rule
@@ -39,7 +40,7 @@ public class RabbitAdminHandlerTest {
     @Before
     public void setup() {
         initMocks(this);
-        tradeshiftRabbitAutoConfiguration = new TunedRabbitAutoConfiguration(context, beanFactory);
+        tradeshiftRabbitAutoConfiguration = new TunedRabbitAutoConfiguration(context, beanFactory, new RabbitComponentsFactory());
     }
 
     @Test

--- a/src/test/java/com/tradeshift/amqp/rabbit/handlers/RabbitAdminHandlerTest.java
+++ b/src/test/java/com/tradeshift/amqp/rabbit/handlers/RabbitAdminHandlerTest.java
@@ -16,7 +16,6 @@ import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.junit4.SpringRunner;
 
 import com.tradeshift.amqp.autoconfigure.TunedRabbitAutoConfiguration;
-import com.tradeshift.amqp.rabbit.components.RabbitComponentsFactory;
 import com.tradeshift.amqp.rabbit.properties.TunedRabbitProperties;
 import com.tradeshift.amqp.rabbit.properties.TunedRabbitPropertiesMap;
 
@@ -40,7 +39,7 @@ public class RabbitAdminHandlerTest {
     @Before
     public void setup() {
         initMocks(this);
-        tradeshiftRabbitAutoConfiguration = new TunedRabbitAutoConfiguration(context, beanFactory, new RabbitComponentsFactory());
+        tradeshiftRabbitAutoConfiguration = new TunedRabbitAutoConfiguration(context, beanFactory);
     }
 
     @Test

--- a/src/test/java/com/tradeshift/amqp/rabbit/handlers/RabbitTemplateHandlerTest.java
+++ b/src/test/java/com/tradeshift/amqp/rabbit/handlers/RabbitTemplateHandlerTest.java
@@ -26,6 +26,7 @@ import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.junit4.SpringRunner;
 
 import com.tradeshift.amqp.autoconfigure.TunedRabbitAutoConfiguration;
+import com.tradeshift.amqp.rabbit.components.RabbitComponentsFactory;
 import com.tradeshift.amqp.rabbit.properties.TunedRabbitProperties;
 import com.tradeshift.amqp.rabbit.properties.TunedRabbitPropertiesMap;
 
@@ -43,7 +44,7 @@ public class RabbitTemplateHandlerTest {
 
     @Autowired
     private ConfigurableListableBeanFactory beanFactory;
-
+    
     private RabbitTemplateHandler rabbitTemplateHandler;
 
     @Rule
@@ -52,7 +53,7 @@ public class RabbitTemplateHandlerTest {
     @Before
     public void setup() {
         initMocks(this);
-        tradeshiftRabbitAutoConfiguration = new TunedRabbitAutoConfiguration(context, beanFactory);
+        tradeshiftRabbitAutoConfiguration = new TunedRabbitAutoConfiguration(context, beanFactory, new RabbitComponentsFactory());
     }
 
     @Test

--- a/src/test/java/com/tradeshift/amqp/rabbit/handlers/RabbitTemplateHandlerTest.java
+++ b/src/test/java/com/tradeshift/amqp/rabbit/handlers/RabbitTemplateHandlerTest.java
@@ -26,7 +26,6 @@ import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.junit4.SpringRunner;
 
 import com.tradeshift.amqp.autoconfigure.TunedRabbitAutoConfiguration;
-import com.tradeshift.amqp.rabbit.components.RabbitComponentsFactory;
 import com.tradeshift.amqp.rabbit.properties.TunedRabbitProperties;
 import com.tradeshift.amqp.rabbit.properties.TunedRabbitPropertiesMap;
 
@@ -53,7 +52,7 @@ public class RabbitTemplateHandlerTest {
     @Before
     public void setup() {
         initMocks(this);
-        tradeshiftRabbitAutoConfiguration = new TunedRabbitAutoConfiguration(context, beanFactory, new RabbitComponentsFactory());
+        tradeshiftRabbitAutoConfiguration = new TunedRabbitAutoConfiguration(context, beanFactory);
     }
 
     @Test


### PR DESCRIPTION
Changes to create the binding when already exists connection for Host, Port and Virtual Host.

Issue #21 