### PR TITLE
Patch 0.1.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,15 +27,15 @@ ___
 <dependency>
   <groupId>com.tradeshift</groupId>
   <artifactId>spring-rabbitmq-tuning-lib</artifactId>
-  <version>0.0.1</version>
+  <version>0.1.0</version>
 </dependency>
 ```
 
 ### Gradle
 
 ```groovy
-implementation 'com.tradeshift:spring-rabbitmq-tuning-lib:0.0.1'
+implementation 'com.tradeshift:spring-rabbitmq-tuning-lib:0.1.0'
 ```
 
 # Current Version
-## 0.0.1
+## 0.1.0

--- a/README.md
+++ b/README.md
@@ -27,15 +27,15 @@ ___
 <dependency>
   <groupId>com.tradeshift</groupId>
   <artifactId>spring-rabbitmq-tuning-lib</artifactId>
-  <version>0.1.0</version>
+  <version>0.1.1</version>
 </dependency>
 ```
 
 ### Gradle
 
 ```groovy
-implementation 'com.tradeshift:spring-rabbitmq-tuning-lib:0.1.0'
+implementation 'com.tradeshift:spring-rabbitmq-tuning-lib:0.1.1'
 ```
 
 # Current Version
-## 0.1.0
+## 0.1.1

--- a/examples/spring-rabbitmq-tuning-examples/spring-rabbitmq-tuning-example-java-without-autoconfig-with-multi-connections/pom.xml
+++ b/examples/spring-rabbitmq-tuning-examples/spring-rabbitmq-tuning-example-java-without-autoconfig-with-multi-connections/pom.xml
@@ -7,6 +7,18 @@
     <groupId>com.tradeshift</groupId>
     <artifactId>spring-rabbitmq-tuning-example-java-without-autoconfig-with-multi-connections</artifactId>
     <version>0.1.0-SNAPSHOT</version>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <source>6</source>
+                    <target>6</target>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
     <packaging>jar</packaging>
 
     <name>Spring RabbitMQ Tuning Example for Java Without Autoconfiguration using Multi Connections</name>

--- a/examples/spring-rabbitmq-tuning-examples/spring-rabbitmq-tuning-example-java-without-autoconfig-with-multi-connections/pom.xml
+++ b/examples/spring-rabbitmq-tuning-examples/spring-rabbitmq-tuning-example-java-without-autoconfig-with-multi-connections/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.tradeshift</groupId>
     <artifactId>spring-rabbitmq-tuning-example-java-without-autoconfig-with-multi-connections</artifactId>
-    <version>0.0.1-SNAPSHOT</version>
+    <version>0.1.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>Spring RabbitMQ Tuning Example for Java Without Autoconfiguration using Multi Connections</name>
@@ -20,7 +20,7 @@
         <dependency>
             <groupId>com.tradeshift</groupId>
             <artifactId>spring-rabbitmq-tuning-lib</artifactId>
-            <version>0.0.1</version>
+            <version>0.1.0</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/examples/spring-rabbitmq-tuning-examples/spring-rabbitmq-tuning-example-java-without-autoconfig-with-multi-connections/src/main/java/com/tradeshift/spring/rabbit/example/listener/SomeListener.java
+++ b/examples/spring-rabbitmq-tuning-examples/spring-rabbitmq-tuning-example-java-without-autoconfig-with-multi-connections/src/main/java/com/tradeshift/spring/rabbit/example/listener/SomeListener.java
@@ -22,7 +22,7 @@ public class SomeListener {
     }
 
     @RabbitListener(containerFactory = "rabbitListenerContainerFactoryDefault", queues = "${spring.rabbitmq.custom.another-event.queue}")
-    @EnableRabbitRetryAndDlq(event = "another-event", exceptions = { IllegalArgumentException.class, RuntimeException.class })
+    @EnableRabbitRetryAndDlq(event = "another-event", retryWhen = { IllegalArgumentException.class, RuntimeException.class })
     public void onMessageAnotherListener(Message message) {
         process(message);
     }

--- a/examples/spring-rabbitmq-tuning-examples/spring-rabbitmq-tuning-example-java-without-autoconfig/pom.xml
+++ b/examples/spring-rabbitmq-tuning-examples/spring-rabbitmq-tuning-example-java-without-autoconfig/pom.xml
@@ -7,6 +7,18 @@
     <groupId>com.tradeshift</groupId>
     <artifactId>spring-rabbitmq-tuning-example-java-without-autoconfig</artifactId>
     <version>0.1.0-SNAPSHOT</version>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <source>6</source>
+                    <target>6</target>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
     <packaging>jar</packaging>
 
     <name>Spring RabbitMQ Tuning Example for Java Without Autoconfiguration</name>

--- a/examples/spring-rabbitmq-tuning-examples/spring-rabbitmq-tuning-example-java-without-autoconfig/pom.xml
+++ b/examples/spring-rabbitmq-tuning-examples/spring-rabbitmq-tuning-example-java-without-autoconfig/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.tradeshift</groupId>
     <artifactId>spring-rabbitmq-tuning-example-java-without-autoconfig</artifactId>
-    <version>0.0.1-SNAPSHOT</version>
+    <version>0.1.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>Spring RabbitMQ Tuning Example for Java Without Autoconfiguration</name>
@@ -20,7 +20,7 @@
         <dependency>
             <groupId>com.tradeshift</groupId>
             <artifactId>spring-rabbitmq-tuning-lib</artifactId>
-            <version>0.0.1</version>
+            <version>0.1.0</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/examples/spring-rabbitmq-tuning-examples/spring-rabbitmq-tuning-example-java/pom.xml
+++ b/examples/spring-rabbitmq-tuning-examples/spring-rabbitmq-tuning-example-java/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.tradeshift</groupId>
     <artifactId>spring-rabbitmq-tuning-example-java</artifactId>
-    <version>0.0.1-SNAPSHOT</version>
+    <version>0.1.0-SNAPSHOT</version>
     <build>
         <plugins>
             <plugin>
@@ -31,7 +31,7 @@
         <dependency>
             <groupId>com.tradeshift</groupId>
             <artifactId>spring-rabbitmq-tuning-lib</artifactId>
-            <version>0.0.1</version>
+            <version>0.1.0</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/examples/spring-rabbitmq-tuning-examples/spring-rabbitmq-tuning-example-java/src/main/java/com/tradeshift/spring/rabbit/example/listener/SomeListener.java
+++ b/examples/spring-rabbitmq-tuning-examples/spring-rabbitmq-tuning-example-java/src/main/java/com/tradeshift/spring/rabbit/example/listener/SomeListener.java
@@ -22,7 +22,7 @@ public class SomeListener {
     }
 
     @RabbitListener(containerFactory = "another-event", queues = "${spring.rabbitmq.custom.another-event.queue}")
-    @EnableRabbitRetryAndDlq(event = "another-event", exceptions = { IllegalArgumentException.class, RuntimeException.class })
+    @EnableRabbitRetryAndDlq(event = "another-event", retryWhen = { IllegalArgumentException.class, RuntimeException.class })
     public void onMessageAnotherListener(Message message) {
         process(message);
     }

--- a/examples/spring-rabbitmq-tuning-examples/spring-rabbitmq-tuning-example-java/src/main/resources/application.properties
+++ b/examples/spring-rabbitmq-tuning-examples/spring-rabbitmq-tuning-example-java/src/main/resources/application.properties
@@ -1,18 +1,19 @@
+spring.rabbitmq.custom.shared.autoCreate=true
+spring.rabbitmq.custom.shared.concurrentConsumers=1
+spring.rabbitmq.custom.shared.maxConcurrentConsumers=1
+spring.rabbitmq.custom.shared.username=guest
+spring.rabbitmq.custom.shared.password=${RABBITMQ_PASS}
+spring.rabbitmq.custom.shared.host=localhost
+spring.rabbitmq.custom.shared.port=5672
+
+spring.rabbitmq.custom.some-event.primary=true
 spring.rabbitmq.custom.some-event.ttlRetryMessage=5000
 spring.rabbitmq.custom.some-event.maxRetriesAttempts=5
 spring.rabbitmq.custom.some-event.queueRoutingKey=ROUTING.KEY.TEST
 spring.rabbitmq.custom.some-event.exchange=ex.custom.direct
 spring.rabbitmq.custom.some-event.exchangeType=direct
 spring.rabbitmq.custom.some-event.queue=queue.custom.test
-spring.rabbitmq.custom.some-event.autoCreate=true
-spring.rabbitmq.custom.some-event.concurrentConsumers=1
-spring.rabbitmq.custom.some-event.maxConcurrentConsumers=1
 spring.rabbitmq.custom.some-event.virtualHost=tradeshift
-spring.rabbitmq.custom.some-event.primary=true
-spring.rabbitmq.custom.some-event.username=guest
-spring.rabbitmq.custom.some-event.password=${RABBITMQ_PASS}
-spring.rabbitmq.custom.some-event.host=localhost
-spring.rabbitmq.custom.some-event.port=5672
 
 spring.rabbitmq.custom.another-event.ttlRetryMessage=5000
 spring.rabbitmq.custom.another-event.maxRetriesAttempts=3
@@ -21,12 +22,5 @@ spring.rabbitmq.custom.another-event.queueRoutingKey=TEST.QUEUE
 spring.rabbitmq.custom.another-event.exchange=ex.test.lib
 spring.rabbitmq.custom.another-event.exchangeType=topic
 spring.rabbitmq.custom.another-event.queue=queue.test.lib
-spring.rabbitmq.custom.another-event.autoCreate=true
-spring.rabbitmq.custom.another-event.concurrentConsumers=1
-spring.rabbitmq.custom.another-event.maxConcurrentConsumers=1
-spring.rabbitmq.custom.another-event.username=guest
-spring.rabbitmq.custom.another-event.password=${RABBITMQ_PASS}
-spring.rabbitmq.custom.another-event.host=localhost
-spring.rabbitmq.custom.another-event.port=5672
 
 #logging.level.root=DEBUG

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.tradeshift</groupId>
     <artifactId>spring-rabbitmq-tuning-lib</artifactId>
-    <version>0.1.0-SNAPSHOT</version>
+    <version>0.1.0</version>
     <packaging>jar</packaging>
 
     <name>Spring RabbitMQ Tuning Library</name>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.tradeshift</groupId>
     <artifactId>spring-rabbitmq-tuning-lib</artifactId>
-    <version>0.0.1-SNAPSHOT</version>
+    <version>0.1.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>Spring RabbitMQ Tuning Library</name>
@@ -38,7 +38,7 @@
         <connection>scm:git:git@github.com:Tradeshift/spring-rabbitmq-tuning.git</connection>
         <developerConnection>scm:git:git@github.com:Tradeshift/spring-rabbitmq-tuning.git</developerConnection>
         <url>https://github.com/Tradeshift/spring-rabbitmq-tuning/tree/master</url>
-        <tag>v0.0.1</tag>
+        <tag>v0.1.0</tag>
     </scm>
 
     <distributionManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.tradeshift</groupId>
     <artifactId>spring-rabbitmq-tuning-lib</artifactId>
-    <version>0.1.0</version>
+    <version>0.1.1-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>Spring RabbitMQ Tuning Library</name>

--- a/src/main/java/com/tradeshift/amqp/autoconfigure/TunedRabbitAutoConfiguration.java
+++ b/src/main/java/com/tradeshift/amqp/autoconfigure/TunedRabbitAutoConfiguration.java
@@ -9,6 +9,7 @@ import com.tradeshift.amqp.rabbit.components.RabbitComponentsFactory;
 import com.tradeshift.amqp.rabbit.handlers.RabbitAdminHandler;
 import com.tradeshift.amqp.rabbit.handlers.RabbitTemplateHandler;
 import com.tradeshift.amqp.rabbit.properties.TunedRabbitProperties;
+import com.tradeshift.amqp.rabbit.properties.TunedRabbitPropertiesBindHandlerAdvisor;
 import com.tradeshift.amqp.rabbit.properties.TunedRabbitPropertiesMap;
 import com.tradeshift.amqp.rabbit.retry.QueueRetryComponent;
 import com.tradeshift.amqp.resolvers.RabbitBeanNameResolver;
@@ -48,7 +49,7 @@ import org.springframework.context.annotation.Primary;
 @Configuration
 @ConditionalOnClass({RabbitTemplate.class, Channel.class})
 @AutoConfigureBefore(RabbitAutoConfiguration.class)
-@Import({TunedRabbitAutoConfiguration.RabbitPostProcessorConfiguration.class})
+@Import({TunedRabbitAutoConfiguration.RabbitPostProcessorConfiguration.class, TunedRabbitPropertiesBindHandlerAdvisor.class })
 public class TunedRabbitAutoConfiguration {
 
     private static final Logger log = LoggerFactory.getLogger(TunedRabbitAutoConfiguration.class);

--- a/src/test/java/com/tradeshift/amqp/rabbit/retry/QueueRetryComponentTest.java
+++ b/src/test/java/com/tradeshift/amqp/rabbit/retry/QueueRetryComponentTest.java
@@ -161,7 +161,7 @@ public class QueueRetryComponentTest {
 
     private MessageProperties createMessageProperties(Integer numberOfDeaths) {
         MessageProperties messageProperties = new MessageProperties();
-        HashMap<String, Integer> map = new HashMap();
+        HashMap<String, Integer> map = new HashMap<>();
         IntStream.range(0, numberOfDeaths).forEach(value -> map.put("count", value));
         messageProperties.getHeaders().put("x-death", Collections.singletonList(map));
         return messageProperties;


### PR DESCRIPTION
Bugfix related to shared properties.

Now we need to explicitly call the `TunedRabbitPropertiesBindHandlerAdvisor` in the Autoconfiguration class.

Examples fixes.