### PR TITLE
Feature/request heartbeat

### DIFF
--- a/src/main/java/com/tradeshift/amqp/rabbit/components/RabbitComponentsFactory.java
+++ b/src/main/java/com/tradeshift/amqp/rabbit/components/RabbitComponentsFactory.java
@@ -60,6 +60,7 @@ public class RabbitComponentsFactory {
 						property.getTlsKeystorePassword().toCharArray()));
 			}
 
+			factory.setRequestedHeartbeat(10);
 			factory.setHost(property.getHost());
 			factory.setPort(property.getPort());
 			factory.setAutomaticRecoveryEnabled(property.isAutomaticRecovery());

--- a/src/main/java/com/tradeshift/amqp/rabbit/components/RabbitComponentsFactory.java
+++ b/src/main/java/com/tradeshift/amqp/rabbit/components/RabbitComponentsFactory.java
@@ -21,6 +21,7 @@ import com.tradeshift.amqp.rabbit.properties.TunedRabbitProperties;
 import com.tradeshift.amqp.ssl.TLSContextUtil;
 
 public class RabbitComponentsFactory {
+
 	private static final Logger log = LoggerFactory.getLogger(RabbitComponentsFactory.class);
 
 
@@ -60,7 +61,7 @@ public class RabbitComponentsFactory {
 						property.getTlsKeystorePassword().toCharArray()));
 			}
 
-			factory.setRequestedHeartbeat(10);
+			factory.setRequestedHeartbeat(property.getHeartbeat());
 			factory.setHost(property.getHost());
 			factory.setPort(property.getPort());
 			factory.setAutomaticRecoveryEnabled(property.isAutomaticRecovery());

--- a/src/main/java/com/tradeshift/amqp/rabbit/properties/TunedRabbitProperties.java
+++ b/src/main/java/com/tradeshift/amqp/rabbit/properties/TunedRabbitProperties.java
@@ -65,6 +65,8 @@ public class TunedRabbitProperties {
 
     private boolean enableLogs = true;
 
+    private int heartbeat = 10;
+
     public TunedRabbitProperties() {
         // Do nothing because this is a empty constructor
     }
@@ -311,5 +313,13 @@ public class TunedRabbitProperties {
 
     public void setEnableLogs(boolean enableLogs) {
         this.enableLogs = enableLogs;
+    }
+
+    public int getHeartbeat() {
+        return heartbeat;
+    }
+
+    public void setHeartbeat(int heartbeat) {
+        this.heartbeat = heartbeat;
     }
 }

--- a/src/test/java/com/tradeshift/amqp/rabbit/properties/TunedRabbitPropertiesTest.java
+++ b/src/test/java/com/tradeshift/amqp/rabbit/properties/TunedRabbitPropertiesTest.java
@@ -66,6 +66,22 @@ public class TunedRabbitPropertiesTest {
         assertTrue(queueProperties.isEnableLogs());
     }
 
+    @Test
+    public void should_return_heartbeat_default() {
+        String queueName = "queue.test.default";
+        TunedRabbitProperties queueProperties = createQueueProperties(queueName, true, false);
+        assertEquals(10, queueProperties.getHeartbeat());
+    }
+
+    @Test
+    public void should_include_heartbeat_default() {
+        String queueName = "queue.test.default";
+        int heartBeat = 60;
+        TunedRabbitProperties queueProperties = createQueueProperties(queueName, true, false);
+        queueProperties.setHeartbeat(heartBeat);
+        assertEquals(60, queueProperties.getHeartbeat());
+    }
+
     private TunedRabbitProperties createQueueProperties(String queue, boolean defaultRetryDlq, boolean enableSnakeCaseForQueuesAndExchangeNames) {
         return createQueueProperties("ex.test", queue, defaultRetryDlq, enableSnakeCaseForQueuesAndExchangeNames);
     }
@@ -88,5 +104,4 @@ public class TunedRabbitPropertiesTest {
 
         return queueProperties;
     }
-
 }


### PR DESCRIPTION
According to the RabbitMQ docs:

The heartbeat timeout value defines after what period of time the peer TCP connection should be considered unreachable (down) by RabbitMQ and client libraries. This value is negotiated between the client and RabbitMQ server at the time of connection. The client must be configured to request heartbeats. In RabbitMQ versions 3.0 and higher, the broker will attempt to negotiate heartbeats by default (although the client can still veto them). The timeout is in seconds, and default value is 60 (580 prior to release 3.5.5).

I am putting this value so that we do not have an error in runtime, idle or idle connection time. This error, he says that disconnects the channel, will only reactivate again if, for example, send another message.