### PR TITLE
Implemented cluster support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,10 @@ traces/
 
 release.properties
 pom.xml.releaseBackup
+
+### Eclipse ###
+.classpath
+.project
+.settings/
+
+.vscode/

--- a/src/main/java/com/tradeshift/amqp/rabbit/annotation/TunedRabbitListenerAnnotationBeanPostProcessor.java
+++ b/src/main/java/com/tradeshift/amqp/rabbit/annotation/TunedRabbitListenerAnnotationBeanPostProcessor.java
@@ -30,7 +30,7 @@ public class TunedRabbitListenerAnnotationBeanPostProcessor
         TunedRabbitProperties tunedRabbitProperties = tunedRabbitPropertiesMap.get(rabbitListener.containerFactory());
 
         TunedRabbitListener tunedRabbitListener = new TunedRabbitListener(rabbitListener);
-        tunedRabbitListener.setContainerFactory(RabbitBeanNameResolver.getSimpleRabbitListenerContainerFactoryBean(tunedRabbitProperties.getVirtualHost(), tunedRabbitProperties.getHost(), tunedRabbitProperties.getPort()));
+        tunedRabbitListener.setContainerFactory(RabbitBeanNameResolver.getSimpleRabbitListenerContainerFactoryBean(tunedRabbitProperties));
         super.processAmqpListener(tunedRabbitListener, method, bean, beanName);
         enhanceBeansWithReferenceToRabbitAdmin(tunedRabbitProperties);
     }

--- a/src/main/java/com/tradeshift/amqp/rabbit/components/RabbitComponentsFactory.java
+++ b/src/main/java/com/tradeshift/amqp/rabbit/components/RabbitComponentsFactory.java
@@ -59,11 +59,18 @@ public class RabbitComponentsFactory {
 				factory.useSslProtocol(TLSContextUtil.tls12ContextFromPKCS12(property.getTlsKeystoreLocation().getInputStream(),
 						property.getTlsKeystorePassword().toCharArray()));
 			}
+			factory.setAutomaticRecoveryEnabled(property.isAutomaticRecovery());
+			Optional.ofNullable(property.getVirtualHost()).ifPresent(factory::setVirtualHost);
+
+			if (property.isClusterMode()) {
+				log.info("Event {} configured with cluster mode on", property.getEventName());
+				CachingConnectionFactory cachingConnectionFactory = new CachingConnectionFactory(factory);
+				cachingConnectionFactory.setAddresses(property.getHosts());
+				return cachingConnectionFactory;
+			}
 
 			factory.setHost(property.getHost());
 			factory.setPort(property.getPort());
-			factory.setAutomaticRecoveryEnabled(property.isAutomaticRecovery());
-			Optional.ofNullable(property.getVirtualHost()).ifPresent(factory::setVirtualHost);
 
 			return new CachingConnectionFactory(factory);
 		} catch (Exception e) {

--- a/src/main/java/com/tradeshift/amqp/rabbit/components/RabbitComponentsFactory.java
+++ b/src/main/java/com/tradeshift/amqp/rabbit/components/RabbitComponentsFactory.java
@@ -64,6 +64,8 @@ public class RabbitComponentsFactory {
 
 			if (property.isClusterMode()) {
 				log.info("Event {} configured with cluster mode on", property.getEventName());
+				factory.setHost(null);
+				factory.setPort(0);
 				CachingConnectionFactory cachingConnectionFactory = new CachingConnectionFactory(factory);
 				cachingConnectionFactory.setAddresses(property.getHosts());
 				return cachingConnectionFactory;

--- a/src/main/java/com/tradeshift/amqp/rabbit/properties/TunedRabbitProperties.java
+++ b/src/main/java/com/tradeshift/amqp/rabbit/properties/TunedRabbitProperties.java
@@ -4,6 +4,9 @@ import java.util.Objects;
 import org.springframework.core.io.Resource;
 
 public class TunedRabbitProperties {
+    private boolean clusterMode = false;
+
+    private String hosts = null;
 
     private String host = "localhost";
 
@@ -259,6 +262,22 @@ public class TunedRabbitProperties {
 
     public void setRabbitTemplateBeanName(final String rabbitTemplateBeanName) {
         this.rabbitTemplateBeanName = rabbitTemplateBeanName;
+    }
+
+    public boolean isClusterMode() {
+        return clusterMode;
+    }
+
+    public void setClusterMode(boolean clusterMode) {
+        this.clusterMode = clusterMode;
+    }
+
+    public String getHosts() {
+        return hosts;
+    }
+
+    public void setHosts(String hosts) {
+        this.hosts = hosts;
     }
 
     public String getHost() {

--- a/src/main/java/com/tradeshift/amqp/resolvers/RabbitBeanNameResolver.java
+++ b/src/main/java/com/tradeshift/amqp/resolvers/RabbitBeanNameResolver.java
@@ -15,7 +15,7 @@ public class RabbitBeanNameResolver {
     // -------------------------------------- ConnectionFactory --------------------------------------
 
     public static String getConnectionFactoryBeanNameForDefaultVirtualHost(TunedRabbitProperties customRabbitProperties) {
-        return getConnectionFactoryBeanName(null, customRabbitProperties.getHost(), customRabbitProperties.getPort());
+        return getConnectionFactoryBeanName(null, getHostAndPortKey(customRabbitProperties));
     }
 
     public static String getConnectionFactoryBeanNameForDefaultVirtualHost(String host, int port) {
@@ -23,7 +23,11 @@ public class RabbitBeanNameResolver {
     }
 
     public static String getConnectionFactoryBeanName(TunedRabbitProperties customRabbitProperties) {
-        return getConnectionFactoryBeanName(customRabbitProperties.getVirtualHost(), customRabbitProperties.getHost() + customRabbitProperties.getPort());
+        return getConnectionFactoryBeanName(customRabbitProperties.getVirtualHost(), getHostAndPortKey(customRabbitProperties));
+    }
+
+    public static String getConnectionFactoryBeanName(String virtualHost, TunedRabbitProperties customRabbitProperties) {
+        return getConnectionFactoryBeanName(virtualHost, getHostAndPortKey(customRabbitProperties));
     }
 
     public static String getConnectionFactoryBeanName(String virtualHost, String host, int port) {
@@ -41,7 +45,7 @@ public class RabbitBeanNameResolver {
     // -------------------------------------- RabbitTemplate --------------------------------------
 
     public static String getRabbitTemplateBeanNameForDefaultVirtualHost(TunedRabbitProperties customRabbitProperties) {
-        return getRabbitTemplateBeanName(null, customRabbitProperties.getHost(), customRabbitProperties.getPort());
+        return getRabbitTemplateBeanName(null, getHostAndPortKey(customRabbitProperties));
     }
 
     public static String getRabbitTemplateBeanNameForDefaultVirtualHost(String host, int port) {
@@ -49,7 +53,11 @@ public class RabbitBeanNameResolver {
     }
 
     public static String getRabbitTemplateBeanName(TunedRabbitProperties customRabbitProperties) {
-        return getRabbitTemplateBeanName(customRabbitProperties.getVirtualHost(), customRabbitProperties.getHost() + customRabbitProperties.getPort());
+        return getRabbitTemplateBeanName(customRabbitProperties.getVirtualHost(), getHostAndPortKey(customRabbitProperties));
+    }
+
+    public static String getRabbitTemplateBeanName(String virtualHost, TunedRabbitProperties customRabbitProperties) {
+        return getRabbitTemplateBeanName(virtualHost, getHostAndPortKey(customRabbitProperties));
     }
 
     public static String getRabbitTemplateBeanName(String virtualHost, String host, int port) {
@@ -67,7 +75,7 @@ public class RabbitBeanNameResolver {
     // -------------------------------------- RabbitAdmin --------------------------------------
 
     public static String getRabbitAdminBeanNameForDefaultVirtualHost(TunedRabbitProperties customRabbitProperties) {
-        return getRabbitAdminBeanName(null, customRabbitProperties.getHost(), customRabbitProperties.getPort());
+        return getRabbitAdminBeanName(null, getHostAndPortKey(customRabbitProperties));
     }
 
     public static String getRabbitAdminBeanNameForDefaultVirtualHost(String host, int port) {
@@ -75,7 +83,11 @@ public class RabbitBeanNameResolver {
     }
 
     public static String getRabbitAdminBeanName(TunedRabbitProperties customRabbitProperties) {
-        return getRabbitAdminBeanName(customRabbitProperties.getVirtualHost(), customRabbitProperties.getHost() + customRabbitProperties.getPort());
+        return getRabbitAdminBeanName(customRabbitProperties.getVirtualHost(), getHostAndPortKey(customRabbitProperties));
+    }
+
+    public static String getRabbitAdminBeanName(String virtualHost, TunedRabbitProperties customRabbitProperties) {
+        return getRabbitAdminBeanName(virtualHost, getHostAndPortKey(customRabbitProperties));
     }
 
     public static String getRabbitAdminBeanName(String virtualHost, String host, int port) {
@@ -97,7 +109,7 @@ public class RabbitBeanNameResolver {
     // -------------------------------------- SimpleRabbitListenerContainerFactory --------------------------------------
 
     public static String getSimpleRabbitListenerContainerFactoryBeanForDefaultVirtualHost(TunedRabbitProperties customRabbitProperties) {
-        return getSimpleRabbitListenerContainerFactoryBean(null, customRabbitProperties.getHost(), customRabbitProperties.getPort());
+        return getSimpleRabbitListenerContainerFactoryBean(null, getHostAndPortKey(customRabbitProperties));
     }
 
     public static String getSimpleRabbitListenerContainerFactoryBeanForDefaultVirtualHost(String host, int port) {
@@ -105,7 +117,11 @@ public class RabbitBeanNameResolver {
     }
 
     public static String getSimpleRabbitListenerContainerFactoryBean(TunedRabbitProperties customRabbitProperties) {
-        return getSimpleRabbitListenerContainerFactoryBean(customRabbitProperties.getVirtualHost(), customRabbitProperties.getHost() + customRabbitProperties.getPort());
+        return getSimpleRabbitListenerContainerFactoryBean(customRabbitProperties.getVirtualHost(), getHostAndPortKey(customRabbitProperties));
+    }
+
+    public static String getSimpleRabbitListenerContainerFactoryBean(String virtualHost, TunedRabbitProperties customRabbitProperties) {
+        return getSimpleRabbitListenerContainerFactoryBean(virtualHost, getHostAndPortKey(customRabbitProperties));
     }
 
     public static String getSimpleRabbitListenerContainerFactoryBean(String virtualHost, String host, int port) {
@@ -124,6 +140,14 @@ public class RabbitBeanNameResolver {
 
     public static String treatVirtualHostName(String virtualHost) {
         return Optional.ofNullable(virtualHost).orElse("Default");
+    }
+
+    private static String getHostAndPortKey(TunedRabbitProperties properties) {
+        if (properties.isClusterMode()) {
+            // TODO: improve so that the order of each host:port in the list doesn't generate different key
+            return properties.getHosts().replaceAll("[:,]", "");
+        }
+        return properties.getHost() + properties.getPort();
     }
 
     protected static String convertSnakeCaseToCamelCase(final String text) {

--- a/src/main/java/com/tradeshift/amqp/resolvers/RabbitBeanNameResolver.java
+++ b/src/main/java/com/tradeshift/amqp/resolvers/RabbitBeanNameResolver.java
@@ -18,10 +18,6 @@ public class RabbitBeanNameResolver {
         return getConnectionFactoryBeanName(null, getHostAndPortKey(customRabbitProperties));
     }
 
-    public static String getConnectionFactoryBeanNameForDefaultVirtualHost(String host, int port) {
-        return getConnectionFactoryBeanName(null, host, port);
-    }
-
     public static String getConnectionFactoryBeanName(TunedRabbitProperties customRabbitProperties) {
         return getConnectionFactoryBeanName(customRabbitProperties.getVirtualHost(), getHostAndPortKey(customRabbitProperties));
     }
@@ -30,11 +26,7 @@ public class RabbitBeanNameResolver {
         return getConnectionFactoryBeanName(virtualHost, getHostAndPortKey(customRabbitProperties));
     }
 
-    public static String getConnectionFactoryBeanName(String virtualHost, String host, int port) {
-        return getConnectionFactoryBeanName(virtualHost, host + port);
-    }
-
-    public static String getConnectionFactoryBeanName(String virtualHost, String hostAndPort) {
+    private static String getConnectionFactoryBeanName(String virtualHost, String hostAndPort) {
         return getConnectionFactoryBeanName(treatVirtualHostName(virtualHost) + "_" + hostAndPort);
     }
 
@@ -48,10 +40,6 @@ public class RabbitBeanNameResolver {
         return getRabbitTemplateBeanName(null, getHostAndPortKey(customRabbitProperties));
     }
 
-    public static String getRabbitTemplateBeanNameForDefaultVirtualHost(String host, int port) {
-        return getRabbitTemplateBeanName(null, host, port);
-    }
-
     public static String getRabbitTemplateBeanName(TunedRabbitProperties customRabbitProperties) {
         return getRabbitTemplateBeanName(customRabbitProperties.getVirtualHost(), getHostAndPortKey(customRabbitProperties));
     }
@@ -60,11 +48,7 @@ public class RabbitBeanNameResolver {
         return getRabbitTemplateBeanName(virtualHost, getHostAndPortKey(customRabbitProperties));
     }
 
-    public static String getRabbitTemplateBeanName(String virtualHost, String host, int port) {
-        return getRabbitTemplateBeanName(virtualHost, host + port);
-    }
-
-    public static String getRabbitTemplateBeanName(String virtualHost, String hostAndPort) {
+    private static String getRabbitTemplateBeanName(String virtualHost, String hostAndPort) {
         return getRabbitTemplateBeanName(treatVirtualHostName(virtualHost) + "_" + hostAndPort);
     }
 
@@ -78,10 +62,6 @@ public class RabbitBeanNameResolver {
         return getRabbitAdminBeanName(null, getHostAndPortKey(customRabbitProperties));
     }
 
-    public static String getRabbitAdminBeanNameForDefaultVirtualHost(String host, int port) {
-        return getRabbitAdminBeanName(null, host, port);
-    }
-
     public static String getRabbitAdminBeanName(TunedRabbitProperties customRabbitProperties) {
         return getRabbitAdminBeanName(customRabbitProperties.getVirtualHost(), getHostAndPortKey(customRabbitProperties));
     }
@@ -90,11 +70,7 @@ public class RabbitBeanNameResolver {
         return getRabbitAdminBeanName(virtualHost, getHostAndPortKey(customRabbitProperties));
     }
 
-    public static String getRabbitAdminBeanName(String virtualHost, String host, int port) {
-        return getRabbitAdminBeanName(virtualHost, host + port);
-    }
-
-    public static String getRabbitAdminBeanName(String virtualHost, String hostAndPort) {
+    private static String getRabbitAdminBeanName(String virtualHost, String hostAndPort) {
         return getRabbitAdminBeanName(treatVirtualHostName(virtualHost) + "_" + hostAndPort, true);
     }
 
@@ -112,20 +88,12 @@ public class RabbitBeanNameResolver {
         return getSimpleRabbitListenerContainerFactoryBean(null, getHostAndPortKey(customRabbitProperties));
     }
 
-    public static String getSimpleRabbitListenerContainerFactoryBeanForDefaultVirtualHost(String host, int port) {
-        return getSimpleRabbitListenerContainerFactoryBean(null, host, port);
-    }
-
     public static String getSimpleRabbitListenerContainerFactoryBean(TunedRabbitProperties customRabbitProperties) {
         return getSimpleRabbitListenerContainerFactoryBean(customRabbitProperties.getVirtualHost(), getHostAndPortKey(customRabbitProperties));
     }
 
     public static String getSimpleRabbitListenerContainerFactoryBean(String virtualHost, TunedRabbitProperties customRabbitProperties) {
         return getSimpleRabbitListenerContainerFactoryBean(virtualHost, getHostAndPortKey(customRabbitProperties));
-    }
-
-    public static String getSimpleRabbitListenerContainerFactoryBean(String virtualHost, String host, int port) {
-        return getSimpleRabbitListenerContainerFactoryBean(virtualHost, host + port);
     }
 
     protected static String getSimpleRabbitListenerContainerFactoryBean(String virtualHost, String hostAndPort) {

--- a/src/test/java/com/tradeshift/amqp/resolvers/RabbitBeanNameResolverTest.java
+++ b/src/test/java/com/tradeshift/amqp/resolvers/RabbitBeanNameResolverTest.java
@@ -4,53 +4,74 @@ import static org.junit.Assert.assertEquals;
 
 import org.junit.Test;
 
+import com.tradeshift.amqp.rabbit.properties.TunedRabbitProperties;
+
 public class RabbitBeanNameResolverTest {
 
-    @Test
-    public void should_return_the_correct_name_for_connection_factory() {
-        assertEquals("connectionFactoryTradeshiftLocalhost5672",
-                RabbitBeanNameResolver.getConnectionFactoryBeanName("tradeshift", "localhost", 5672));
-    }
+	@Test
+	public void should_return_the_correct_name_for_default_connection_factory_from_properties() {
+		assertEquals("connectionFactoryDefaultLocalhost5672", RabbitBeanNameResolver
+				.getConnectionFactoryBeanName(createQueueProperties("localhost", 5672, null)));
+	}
 
-    @Test
-    public void should_return_the_correct_name_for_rabbit_admin() {
-        assertEquals("rabbitAdminTradeshiftLocalhost5672",
-                RabbitBeanNameResolver.getRabbitAdminBeanName("tradeshift", "localhost", 5672));
-    }
+	@Test
+	public void should_return_the_correct_name_for_connection_factory_from_properties() {
+		assertEquals("connectionFactoryTradeshiftLocalhost5672", RabbitBeanNameResolver
+				.getConnectionFactoryBeanName(createQueueProperties("localhost", 5672, "tradeshift")));
+	}
 
-    @Test
-    public void should_return_the_correct_name_for_rabbit_template() {
-        assertEquals("rabbitTemplateTradeshiftLocalhost5672",
-                RabbitBeanNameResolver.getRabbitTemplateBeanName("tradeshift", "localhost", 5672));
-    }
+	@Test
+	public void should_return_the_correct_name_for_default_rabbit_admin_from_properties() {
+		assertEquals("rabbitAdminDefaultLocalhost5672", RabbitBeanNameResolver
+				.getRabbitAdminBeanName(createQueueProperties("localhost", 5672, null)));
+	}
 
-    @Test
-    public void should_return_the_correct_name_for_listener_container_factory() {
-        assertEquals("containerFactoryTradeshiftLocalhost5672",
-                RabbitBeanNameResolver.getSimpleRabbitListenerContainerFactoryBean("tradeshift", "localhost", 5672));
-    }
+	@Test
+	public void should_return_the_correct_name_for_rabbit_admin_from_properties() {
+		assertEquals("rabbitAdminTradeshiftLocalhost5672", RabbitBeanNameResolver
+				.getRabbitAdminBeanName(createQueueProperties("localhost", 5672, "tradeshift")));
+	}
 
-    @Test
-    public void should_return_the_correct_name_for_default_connection_factory() {
-        assertEquals("connectionFactoryDefaultLocalhost5671",
-                RabbitBeanNameResolver.getConnectionFactoryBeanNameForDefaultVirtualHost("localhost", 5671));
-    }
+	@Test
+	public void should_return_the_correct_name_for_default_rabbit_template_from_properties() {
+		assertEquals("rabbitTemplateDefaultLocalhost5672", RabbitBeanNameResolver
+				.getRabbitTemplateBeanName(createQueueProperties("localhost", 5672, null)));
+	}
 
-    @Test
-    public void should_return_the_correct_name_for_default_rabbit_admin() {
-        assertEquals("rabbitAdminDefaultLocalhost5671",
-                RabbitBeanNameResolver.getRabbitAdminBeanNameForDefaultVirtualHost("localhost", 5671));
-    }
+	@Test
+	public void should_return_the_correct_name_for_rabbit_template_from_properties() {
+		assertEquals("rabbitTemplateTradeshiftLocalhost5672", RabbitBeanNameResolver
+				.getRabbitTemplateBeanName(createQueueProperties("localhost", 5672, "tradeshift")));
+	}
 
-    @Test
-    public void should_return_the_correct_name_for_default_rabbit_template() {
-        assertEquals("rabbitTemplateDefaultLocalhost5671",
-                RabbitBeanNameResolver.getRabbitTemplateBeanNameForDefaultVirtualHost("localhost", 5671));
-    }
+	@Test
+	public void should_return_the_correct_name_for_default_listener_container_factory_from_properties() {
+		assertEquals("containerFactoryDefaultLocalhost5672", RabbitBeanNameResolver
+				.getSimpleRabbitListenerContainerFactoryBean(createQueueProperties("localhost", 5672, null)));
+	}
 
-    @Test
-    public void should_return_the_correct_name_for_default_listener_container_factory() {
-        assertEquals("containerFactoryDefaultLocalhost5671",
-                RabbitBeanNameResolver.getSimpleRabbitListenerContainerFactoryBeanForDefaultVirtualHost("localhost", 5671));
-    }
+	@Test
+	public void should_return_the_correct_name_for_listener_container_factory_from_properties() {
+		assertEquals("containerFactoryTradeshiftLocalhost5672", RabbitBeanNameResolver
+				.getSimpleRabbitListenerContainerFactoryBean(createQueueProperties("localhost", 5672, "tradeshift")));
+	}
+
+	private TunedRabbitProperties createQueueProperties(String host, int port, String virtualHost) {
+		TunedRabbitProperties queueProperties = new TunedRabbitProperties();
+		queueProperties.setHost(host);
+		queueProperties.setPort(port);
+		queueProperties.setVirtualHost(virtualHost);
+		queueProperties.setQueue("some-queue");
+		queueProperties.setExchange("some-exchange");
+		queueProperties.setExchangeType("topic");
+		queueProperties.setMaxRetriesAttempts(5);
+		queueProperties.setQueueRoutingKey("routing.key.test");
+		queueProperties.setTtlRetryMessage(3000);
+		queueProperties.setPrimary(true);
+		queueProperties.setUsername("guest");
+		queueProperties.setPassword("guest");
+		queueProperties.setDefaultRetryDlq(true);
+		queueProperties.setSslConnection(false);
+		return queueProperties;
+	}
 }

--- a/src/test/java/com/tradeshift/amqp/resolvers/RabbitBeanNameResolverTest.java
+++ b/src/test/java/com/tradeshift/amqp/resolvers/RabbitBeanNameResolverTest.java
@@ -21,6 +21,18 @@ public class RabbitBeanNameResolverTest {
 	}
 
 	@Test
+	public void should_return_the_correct_name_for_default_connection_factory_from_properties_with_cluster_mode() {
+		assertEquals("connectionFactoryDefaultLocalhost5672localhost6672", RabbitBeanNameResolver
+				.getConnectionFactoryBeanName(createQueuePropertiesInClusterMode("localhost:5672,localhost:6672", null)));
+	}
+
+	@Test
+	public void should_return_the_correct_name_for_connection_factory_from_properties_with_cluster_mode() {
+		assertEquals("connectionFactoryTradeshiftLocalhost5672localhost6672", RabbitBeanNameResolver
+				.getConnectionFactoryBeanName(createQueuePropertiesInClusterMode("localhost:5672,localhost:6672", "tradeshift")));
+	}
+
+	@Test
 	public void should_return_the_correct_name_for_default_rabbit_admin_from_properties() {
 		assertEquals("rabbitAdminDefaultLocalhost5672", RabbitBeanNameResolver
 				.getRabbitAdminBeanName(createQueueProperties("localhost", 5672, null)));
@@ -30,6 +42,18 @@ public class RabbitBeanNameResolverTest {
 	public void should_return_the_correct_name_for_rabbit_admin_from_properties() {
 		assertEquals("rabbitAdminTradeshiftLocalhost5672", RabbitBeanNameResolver
 				.getRabbitAdminBeanName(createQueueProperties("localhost", 5672, "tradeshift")));
+	}
+
+	@Test
+	public void should_return_the_correct_name_for_default_rabbit_admin_from_properties_with_cluster_mode() {
+		assertEquals("rabbitAdminDefaultLocalhost5672localhost6672", RabbitBeanNameResolver
+				.getRabbitAdminBeanName(createQueuePropertiesInClusterMode("localhost:5672,localhost:6672", null)));
+	}
+
+	@Test
+	public void should_return_the_correct_name_for_rabbit_admin_from_properties_with_cluster_mode() {
+		assertEquals("rabbitAdminTradeshiftLocalhost5672localhost6672", RabbitBeanNameResolver
+				.getRabbitAdminBeanName(createQueuePropertiesInClusterMode("localhost:5672,localhost:6672", "tradeshift")));
 	}
 
 	@Test
@@ -45,6 +69,18 @@ public class RabbitBeanNameResolverTest {
 	}
 
 	@Test
+	public void should_return_the_correct_name_for_default_rabbit_template_from_properties_with_cluster_mode() {
+		assertEquals("rabbitTemplateDefaultLocalhost5672localhost6672", RabbitBeanNameResolver
+				.getRabbitTemplateBeanName(createQueuePropertiesInClusterMode("localhost:5672,localhost:6672", null)));
+	}
+
+	@Test
+	public void should_return_the_correct_name_for_rabbit_template_from_properties_with_cluster_mode() {
+		assertEquals("rabbitTemplateTradeshiftLocalhost5672localhost6672", RabbitBeanNameResolver
+				.getRabbitTemplateBeanName(createQueuePropertiesInClusterMode("localhost:5672,localhost:6672", "tradeshift")));
+	}
+
+	@Test
 	public void should_return_the_correct_name_for_default_listener_container_factory_from_properties() {
 		assertEquals("containerFactoryDefaultLocalhost5672", RabbitBeanNameResolver
 				.getSimpleRabbitListenerContainerFactoryBean(createQueueProperties("localhost", 5672, null)));
@@ -56,8 +92,34 @@ public class RabbitBeanNameResolverTest {
 				.getSimpleRabbitListenerContainerFactoryBean(createQueueProperties("localhost", 5672, "tradeshift")));
 	}
 
+	@Test
+	public void should_return_the_correct_name_for_default_container_factory_from_properties_with_cluster_mode() {
+		assertEquals("containerFactoryDefaultLocalhost5672localhost6672", RabbitBeanNameResolver
+				.getSimpleRabbitListenerContainerFactoryBean(createQueuePropertiesInClusterMode("localhost:5672,localhost:6672", null)));
+	}
+
+	@Test
+	public void should_return_the_correct_name_for_container_factory_from_properties_with_cluster_mode() {
+		assertEquals("containerFactoryTradeshiftLocalhost5672localhost6672", RabbitBeanNameResolver
+				.getSimpleRabbitListenerContainerFactoryBean(createQueuePropertiesInClusterMode("localhost:5672,localhost:6672", "tradeshift")));
+	}
+
+
 	private TunedRabbitProperties createQueueProperties(String host, int port, String virtualHost) {
+		return createQueueProperties(host, port, null, virtualHost);
+	}
+
+
+	private TunedRabbitProperties createQueuePropertiesInClusterMode(String hosts, String virtualHost) {
+		return createQueueProperties(null, 0, hosts, virtualHost);
+	}
+
+	private TunedRabbitProperties createQueueProperties(String host, int port, String hosts, String virtualHost) {
 		TunedRabbitProperties queueProperties = new TunedRabbitProperties();
+		if (hosts != null && !hosts.isEmpty()) {
+			queueProperties.setClusterMode(true);
+			queueProperties.setHosts(hosts);
+		}
 		queueProperties.setHost(host);
 		queueProperties.setPort(port);
 		queueProperties.setVirtualHost(virtualHost);


### PR DESCRIPTION
As requested in issue #35 .

New properties were added, the following content should be added in [Properties Documention](https://github.com/Tradeshift/spring-rabbitmq-tuning/wiki/Properties-Documentation) section:

| Property | Definition | Default Value |
| - | - | - |
| clusterMode | Define if should use cluster mode. When `true`, the properties `host` and `port` are ignored. | false |
| hosts | Comma-separated list of addresses (`[host]:[port]`) to which the client should connect. | |
