### PR TITLE
Adding support to version 2.2.x.RELEASE

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ This library makes it easy to configure RabbitMQ for use with Spring.
 ___
 
 ## Technologies
- This lib uses **Java 8** and **Spring Boot 2.1.x.RELEASE**
+ This lib uses **Java 8** and **Spring Boot 2.2.x.RELEASE**
  
 ## Adding in your project
 

--- a/examples/spring-rabbitmq-tuning-examples/spring-rabbitmq-tuning-example-java-without-autoconfig-with-multi-connections/pom.xml
+++ b/examples/spring-rabbitmq-tuning-examples/spring-rabbitmq-tuning-example-java-without-autoconfig-with-multi-connections/pom.xml
@@ -25,14 +25,14 @@
     <description>Example module to showcase with Java</description>
 
     <properties>
-        <springboot.version>2.1.4.RELEASE</springboot.version>
+        <springboot.version>2.2.4.RELEASE</springboot.version>
     </properties>
 
     <dependencies>
         <dependency>
             <groupId>com.tradeshift</groupId>
             <artifactId>spring-rabbitmq-tuning-lib</artifactId>
-            <version>0.1.2</version>
+            <version>0.1.3-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/examples/spring-rabbitmq-tuning-examples/spring-rabbitmq-tuning-example-java-without-autoconfig/pom.xml
+++ b/examples/spring-rabbitmq-tuning-examples/spring-rabbitmq-tuning-example-java-without-autoconfig/pom.xml
@@ -25,14 +25,14 @@
     <description>Example module to showcase with Java</description>
 
     <properties>
-        <springboot.version>2.1.4.RELEASE</springboot.version>
+        <springboot.version>2.2.4.RELEASE</springboot.version>
     </properties>
 
     <dependencies>
         <dependency>
             <groupId>com.tradeshift</groupId>
             <artifactId>spring-rabbitmq-tuning-lib</artifactId>
-            <version>0.1.2</version>
+            <version>0.1.3-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/examples/spring-rabbitmq-tuning-examples/spring-rabbitmq-tuning-example-java/pom.xml
+++ b/examples/spring-rabbitmq-tuning-examples/spring-rabbitmq-tuning-example-java/pom.xml
@@ -24,14 +24,14 @@
     <description>Example module to showcase with Java</description>
 
     <properties>
-        <springboot.version>2.1.4.RELEASE</springboot.version>
+        <springboot.version>2.2.4.RELEASE</springboot.version>
     </properties>
 
     <dependencies>
         <dependency>
             <groupId>com.tradeshift</groupId>
             <artifactId>spring-rabbitmq-tuning-lib</artifactId>
-            <version>0.1.2</version>
+            <version>0.1.3-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/examples/spring-rabbitmq-tuning-examples/spring-rabbitmq-tuning-example-java/src/main/resources/application.properties
+++ b/examples/spring-rabbitmq-tuning-examples/spring-rabbitmq-tuning-example-java/src/main/resources/application.properties
@@ -2,7 +2,7 @@ spring.rabbitmq.custom.shared.autoCreate=true
 spring.rabbitmq.custom.shared.concurrentConsumers=1
 spring.rabbitmq.custom.shared.maxConcurrentConsumers=1
 spring.rabbitmq.custom.shared.username=guest
-spring.rabbitmq.custom.shared.password=${RABBITMQ_PASS}
+spring.rabbitmq.custom.shared.password=guest
 spring.rabbitmq.custom.shared.host=localhost
 spring.rabbitmq.custom.shared.port=5672
 

--- a/pom.xml
+++ b/pom.xml
@@ -55,7 +55,7 @@
     <properties>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
-        <springboot.version>2.1.4.RELEASE</springboot.version>
+        <springboot.version>2.2.4.RELEASE</springboot.version>
     </properties>
 
     <dependencyManagement>

--- a/src/main/java/com/tradeshift/amqp/annotation/TunedRabbitListener.java
+++ b/src/main/java/com/tradeshift/amqp/annotation/TunedRabbitListener.java
@@ -21,6 +21,8 @@ public class TunedRabbitListener implements RabbitListener {
     private String errorHandler = "";
     private String concurrency = "";
     private String autoStartup = "";
+    private String executor = "";
+    private String ackMode = "";
 
 
     public TunedRabbitListener(RabbitListener rabbitListener) {
@@ -37,6 +39,8 @@ public class TunedRabbitListener implements RabbitListener {
         this.errorHandler = rabbitListener.errorHandler();
         this.concurrency = rabbitListener.concurrency();
         this.autoStartup = rabbitListener.autoStartup();
+        this.executor = rabbitListener.executor();
+        this.ackMode = rabbitListener.ackMode();
     }
 
     @Override
@@ -102,6 +106,16 @@ public class TunedRabbitListener implements RabbitListener {
     @Override
     public String autoStartup() {
         return this.autoStartup;
+    }
+
+    @Override
+    public String executor() {
+        return this.executor;
+    }
+
+    @Override
+    public String ackMode() {
+        return this.ackMode;
     }
 
     @Override

--- a/src/test/java/com/tradeshift/amqp/autoconfigure/TunedRabbitAutoConfigurationTest.java
+++ b/src/test/java/com/tradeshift/amqp/autoconfigure/TunedRabbitAutoConfigurationTest.java
@@ -543,8 +543,8 @@ public class TunedRabbitAutoConfigurationTest {
         // assure that have hosts
         Field addressesField = AbstractConnectionFactory.class.getDeclaredField("addresses");
         addressesField.setAccessible(true);
-        Address[] addresses = (Address[]) addressesField.get(connectionFactory);
-        List<String> hosts = Stream.of(addresses)
+        List<Address> addresses = (List<Address>) addressesField.get(connectionFactory);
+        List<String> hosts = addresses.stream()
                 .map(a -> String.format("%s:%d", a.getHost(), a.getPort()))
                 .collect(toList());
         assertThat(hosts, Matchers.containsInAnyOrder("127.0.0.1:5672", "127.0.0.1:6672"));


### PR DESCRIPTION
Now, this library will support version 2.2.x.RELEASE of Spring Boot.

Basicaly the only change was in the `RabbitListener` annotation that now has 2 more parameters:
- executor
- ackMode

See more: https://docs.spring.io/spring-amqp/reference/html/#_rabbitlistener_changes

Issue: https://github.com/Tradeshift/spring-rabbitmq-tuning/issues/26