### PR TITLE
Adding support to version 2.5.13

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.tradeshift</groupId>
     <artifactId>spring-rabbitmq-tuning-lib</artifactId>
-    <version>0.1.3-SNAPSHOT</version>
+    <version>0.1.4-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>Spring RabbitMQ Tuning Library</name>
@@ -38,7 +38,7 @@
         <connection>scm:git:git@github.com:Tradeshift/spring-rabbitmq-tuning.git</connection>
         <developerConnection>scm:git:git@github.com:Tradeshift/spring-rabbitmq-tuning.git</developerConnection>
         <url>https://github.com/Tradeshift/spring-rabbitmq-tuning/tree/master</url>
-        <tag>v0.1.2</tag>
+        <tag>v0.1.4</tag>
     </scm>
 
     <distributionManagement>
@@ -55,7 +55,7 @@
     <properties>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
-        <springboot.version>2.2.4.RELEASE</springboot.version>
+        <springboot.version>2.2.13.RELEASE</springboot.version>
     </properties>
 
     <dependencyManagement>
@@ -99,7 +99,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.9.10.7</version>
+            <version>2.9.10.8</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.tradeshift</groupId>
     <artifactId>spring-rabbitmq-tuning-lib</artifactId>
-    <version>0.1.4-SNAPSHOT</version>
+    <version>0.1.5-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>Spring RabbitMQ Tuning Library</name>
@@ -38,7 +38,7 @@
         <connection>scm:git:git@github.com:Tradeshift/spring-rabbitmq-tuning.git</connection>
         <developerConnection>scm:git:git@github.com:Tradeshift/spring-rabbitmq-tuning.git</developerConnection>
         <url>https://github.com/Tradeshift/spring-rabbitmq-tuning/tree/master</url>
-        <tag>v0.1.4</tag>
+        <tag>v0.1.5</tag>
     </scm>
 
     <distributionManagement>
@@ -55,7 +55,7 @@
     <properties>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
-        <springboot.version>2.2.13.RELEASE</springboot.version>
+        <springboot.version>2.5.13</springboot.version>
     </properties>
 
     <dependencyManagement>

--- a/src/main/java/com/tradeshift/amqp/annotation/TunedRabbitListener.java
+++ b/src/main/java/com/tradeshift/amqp/annotation/TunedRabbitListener.java
@@ -24,7 +24,9 @@ public class TunedRabbitListener implements RabbitListener {
     private String executor = "";
     private String ackMode = "";
     private String replyPostProcessor = "";
-
+    private String messageConverter = "";
+    private String replyContentType = "";
+    private String converterWinsContentType = "true";
 
     public TunedRabbitListener(RabbitListener rabbitListener) {
         this.id = rabbitListener.id();
@@ -43,6 +45,9 @@ public class TunedRabbitListener implements RabbitListener {
         this.executor = rabbitListener.executor();
         this.ackMode = rabbitListener.ackMode();
         this.replyPostProcessor = rabbitListener.replyPostProcessor();
+        this.messageConverter = rabbitListener.messageConverter();
+        this.replyContentType = rabbitListener.replyContentType();
+        this.converterWinsContentType = rabbitListener.converterWinsContentType();
     }
 
     @Override
@@ -123,6 +128,21 @@ public class TunedRabbitListener implements RabbitListener {
     @Override
     public String replyPostProcessor() {
         return this.replyPostProcessor;
+    }
+
+    @Override
+    public String messageConverter() {
+        return this.messageConverter;
+    }
+
+    @Override
+    public String replyContentType() {
+        return this.replyContentType;
+    }
+
+    @Override
+    public String converterWinsContentType() {
+        return this.converterWinsContentType;
     }
 
     @Override

--- a/src/main/java/com/tradeshift/amqp/annotation/TunedRabbitListener.java
+++ b/src/main/java/com/tradeshift/amqp/annotation/TunedRabbitListener.java
@@ -23,6 +23,7 @@ public class TunedRabbitListener implements RabbitListener {
     private String autoStartup = "";
     private String executor = "";
     private String ackMode = "";
+    private String replyPostProcessor = "";
 
 
     public TunedRabbitListener(RabbitListener rabbitListener) {
@@ -41,6 +42,7 @@ public class TunedRabbitListener implements RabbitListener {
         this.autoStartup = rabbitListener.autoStartup();
         this.executor = rabbitListener.executor();
         this.ackMode = rabbitListener.ackMode();
+        this.replyPostProcessor = rabbitListener.replyPostProcessor();
     }
 
     @Override
@@ -116,6 +118,11 @@ public class TunedRabbitListener implements RabbitListener {
     @Override
     public String ackMode() {
         return this.ackMode;
+    }
+
+    @Override
+    public String replyPostProcessor() {
+        return this.replyPostProcessor;
     }
 
     @Override

--- a/src/main/java/com/tradeshift/amqp/rabbit/annotation/TunedRabbitListenerAnnotationBeanPostProcessor.java
+++ b/src/main/java/com/tradeshift/amqp/rabbit/annotation/TunedRabbitListenerAnnotationBeanPostProcessor.java
@@ -1,6 +1,7 @@
 package com.tradeshift.amqp.rabbit.annotation;
 
 import java.lang.reflect.Method;
+import java.util.Collection;
 
 import org.springframework.amqp.core.AbstractExchange;
 import org.springframework.amqp.core.Binding;
@@ -25,14 +26,15 @@ public class TunedRabbitListenerAnnotationBeanPostProcessor
     private ApplicationContext applicationContext;
 
     @Override
-    protected void processAmqpListener(RabbitListener rabbitListener, Method method, Object bean, String beanName) {
+    protected Collection<Declarable> processAmqpListener(RabbitListener rabbitListener, Method method, Object bean, String beanName) {
         TunedRabbitPropertiesMap tunedRabbitPropertiesMap = applicationContext.getBean(TunedRabbitPropertiesMap.class);
         TunedRabbitProperties tunedRabbitProperties = tunedRabbitPropertiesMap.get(rabbitListener.containerFactory());
 
         TunedRabbitListener tunedRabbitListener = new TunedRabbitListener(rabbitListener);
         tunedRabbitListener.setContainerFactory(RabbitBeanNameResolver.getSimpleRabbitListenerContainerFactoryBean(tunedRabbitProperties));
-        super.processAmqpListener(tunedRabbitListener, method, bean, beanName);
+        Collection<Declarable> declarables = super.processAmqpListener(tunedRabbitListener, method, bean, beanName);
         enhanceBeansWithReferenceToRabbitAdmin(tunedRabbitProperties);
+        return declarables;
     }
 
     private void enhanceBeansWithReferenceToRabbitAdmin(TunedRabbitProperties tunedRabbitProperties) {

--- a/src/test/java/com/tradeshift/amqp/rabbit/retry/QueueRetryComponentTest.java
+++ b/src/test/java/com/tradeshift/amqp/rabbit/retry/QueueRetryComponentTest.java
@@ -96,7 +96,7 @@ public class QueueRetryComponentTest {
     @Test
     public void should_call_send_to_dlq_with_correct_params() {
         when(rabbitTemplateHandler.getRabbitTemplate(Mockito.any(TunedRabbitProperties.class))).thenReturn(rabbitTemplate);
-        doNothing().when(rabbitTemplate).send(Mockito.any(), Mockito.any(), Mockito.any());
+        doNothing().when(rabbitTemplate).send(Mockito.any(), Mockito.any(), Mockito.any(Message.class));
 
         MessageProperties messageProperties = createMessageProperties(3);
         Message message = new Message("some".getBytes(), messageProperties);
@@ -111,7 +111,7 @@ public class QueueRetryComponentTest {
     @Test
     public void should_call_send_to_retry_with_correct_params_without_ttl_message() {
         when(rabbitTemplateHandler.getRabbitTemplate(Mockito.any(TunedRabbitProperties.class))).thenReturn(rabbitTemplate);
-        doNothing().when(rabbitTemplate).send(Mockito.any(), Mockito.any(), Mockito.any());
+        doNothing().when(rabbitTemplate).send(Mockito.any(), Mockito.any(), Mockito.any(Message.class));
 
         int numberOfDeaths = 3;
         MessageProperties messageProperties = createMessageProperties(numberOfDeaths);
@@ -128,7 +128,7 @@ public class QueueRetryComponentTest {
     @Test
     public void should_call_send_to_retry_and_sent_to_dlq_based_on_max_retries() {
         when(rabbitTemplateHandler.getRabbitTemplate(Mockito.any(TunedRabbitProperties.class))).thenReturn(rabbitTemplate);
-        doNothing().when(rabbitTemplate).send(Mockito.any(), Mockito.any(), Mockito.any());
+        doNothing().when(rabbitTemplate).send(Mockito.any(), Mockito.any(), Mockito.any(Message.class));
 
         int maxRetry = 5;
         TunedRabbitProperties queueProperties = createQueueProperties(2, maxRetry);
@@ -145,7 +145,7 @@ public class QueueRetryComponentTest {
     @Test
     public void should_call_send_to_retry_and_sent_to_dlq_based_on_max_retries_again() {
         when(rabbitTemplateHandler.getRabbitTemplate(Mockito.any(TunedRabbitProperties.class))).thenReturn(rabbitTemplate);
-        doNothing().when(rabbitTemplate).send(Mockito.any(), Mockito.any(), Mockito.any());
+        doNothing().when(rabbitTemplate).send(Mockito.any(), Mockito.any(), Mockito.any(Message.class));
 
         int maxRetry = 10;
         TunedRabbitProperties queueProperties = createQueueProperties(2, maxRetry);


### PR DESCRIPTION
Adding support to version Spring Boot 2.5.13. I'm planning to try to support 2.6.x (2.5.x support goes until 2022-05-19).
Also the version of Jackson Databind was upgraded to 2.9.10.8 (security fix).

I didn't use the returned `Collection<Declarable>` in the `TunedRabbitListenerAnnotationBeanPostProcessor.processAmqpListener` because it is already iterate over the beans to set the Admin.
